### PR TITLE
Fix parser to parse flag with `.`(dot).

### DIFF
--- a/oelint_parser/parser.py
+++ b/oelint_parser/parser.py
@@ -151,7 +151,7 @@ def get_items(stash, _file, lineOffset=0):
         list: List of oelint_parser.cls_item.* representations
     """
     res = []
-    __regex_var = r"^(?P<varname>([A-Z0-9a-z_-]|\$|\{|\}|:)+?)(\[(?P<ident>(\w|-)+)\])*(?P<varop>(\s|\t)*(\+|\?|\:|\.)*=(\+|\.)*(\s|\t)*)(?P<varval>.*)"
+    __regex_var = r"^(?P<varname>([A-Z0-9a-z_-]|\$|\{|\}|:)+?)(\[(?P<ident>(\w|-|\.)+)\])*(?P<varop>(\s|\t)*(\+|\?|\:|\.)*=(\+|\.)*(\s|\t)*)(?P<varval>.*)"
     __regex_func = r"^((?P<py>python)\s*|(?P<fr>fakeroot\s*))*(?P<func>[\w\.\-\+\{\}:\$]+)?\s*\(\s*\)\s*\{(?P<funcbody>.*)\s*\}"
     __regex_inherit = r"^.*?inherit(\s+|\t+)(?P<inhname>.+)"
     __regex_export_wval = r"^.*?export(\s+|\t+)(?P<name>.+)\s*=\s*\"(?P<value>.*)\""

--- a/tests/test-recipe-new_1.0.bb
+++ b/tests/test-recipe-new_1.0.bb
@@ -1,3 +1,6 @@
+SRC_URI = "http://example.com/foobar.tar.bz2;name=foo"
+SRC_URI[foo.md5sum] = "5c274e52576976bd70565cd72505db41"
+
 A:append = " X"
 
 B:remove:qemuall = "X2"

--- a/tests/test_parser_new.py
+++ b/tests/test_parser_new.py
@@ -61,6 +61,27 @@ class OelintParserTestNew(unittest.TestCase):
             self.assertEqual(x.SubItems, ["remove", "qemuall"])
             self.assertEqual(x.VarOp, " = ")
 
+    def test_var_src_uri(self):
+        from oelint_parser.cls_item import Variable
+        from oelint_parser.helper_files import expand_term
+        from oelint_parser.cls_stash import Stash
+
+        self.__stash = Stash()
+        self.__stash.AddFile(OelintParserTestNew.RECIPE)
+
+        _stash = self.__stash.GetItemsFor(classifier=Variable.CLASSIFIER,
+                                          attribute=Variable.ATTR_VARRAW,
+                                          attributeValue="SRC_URI[foo.md5sum]")
+        self.assertTrue(_stash, msg="Stash has no items")
+        for x in _stash:
+            self.assertEqual(x.VarValue, '"5c274e52576976bd70565cd72505db41"')
+            self.assertEqual(x.VarValueStripped, '5c274e52576976bd70565cd72505db41')
+            self.assertEqual(x.VarName, 'SRC_URI')
+            self.assertEqual(x.Flag, "foo.md5sum")
+            self.assertEqual(x.RawVarName, 'SRC_URI[foo.md5sum]')
+            self.assertEqual(x.get_items(), ["5c274e52576976bd70565cd72505db41"])
+            self.assertEqual(x.VarOp, " = ")
+
     def test_var_rdepends(self):
         from oelint_parser.cls_item import Variable
         from oelint_parser.helper_files import expand_term


### PR DESCRIPTION
Each source of SRC_URI can have a name. And the checksum is expressed as:

SRC_URI = "http://example.com/foo.tar.bz2;name=foo
           http://example.com/bar.tar.bz2;name=bar"
SRC_URI[foo.md5sum] = "5c274e52576976bd70565cd72505db41" SRC_URI[bar.md5sum] = "9e822cc27b4a419529572b422c9c3970"

But current parser cannot parse flag with `.`(dot).