### PR TITLE
parser: let varname also contain '.'

### DIFF
--- a/oelint_parser/parser.py
+++ b/oelint_parser/parser.py
@@ -151,7 +151,7 @@ def get_items(stash, _file, lineOffset=0):
         list: List of oelint_parser.cls_item.* representations
     """
     res = []
-    __regex_var = r"^(?P<varname>([A-Z0-9a-z_-]|\$|\{|\}|:)+?)(\[(?P<ident>(\w|-|\.)+)\])*(?P<varop>(\s|\t)*(\+|\?|\:|\.)*=(\+|\.)*(\s|\t)*)(?P<varval>.*)"
+    __regex_var = r"^(?P<varname>([A-Z0-9a-z_.-]|\$|\{|\}|:)+?)(\[(?P<ident>(\w|-|\.)+)\])*(?P<varop>(\s|\t)*(\+|\?|\:|\.)*=(\+|\.)*(\s|\t)*)(?P<varval>.*)"
     __regex_func = r"^((?P<py>python)\s*|(?P<fr>fakeroot\s*))*(?P<func>[\w\.\-\+\{\}:\$]+)?\s*\(\s*\)\s*\{(?P<funcbody>.*)\s*\}"
     __regex_inherit = r"^.*?inherit(\s+|\t+)(?P<inhname>.+)"
     __regex_export_wval = r"^\s*?export(\s+|\t+)(?P<name>.+)\s*=\s*\"(?P<value>.*)\""

--- a/tests/test-recipe_1.0.bb
+++ b/tests/test-recipe_1.0.bb
@@ -1,6 +1,7 @@
 LICENSE = "BSD-2-Clause"
 SOMEOTHERVAR = "${SOMEVAR}/SOMEMORE"
 SOMEVAR = "source"
+SOME.VAR.WITH.PERIODS = "foo"
 SOMELIST += "a \
              b \
              c \ 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -43,6 +43,32 @@ class OelintParserTest(unittest.TestCase):
             self.assertEqual(x.Flag, "")
             self.assertEqual(x.GetClassOverride(), "")
 
+    def test_some_var_with_periods(self):
+        from oelint_parser.cls_item import Variable
+        from oelint_parser.cls_stash import Stash
+
+        self.__stash = Stash()
+        self.__stash.AddFile(OelintParserTest.RECIPE)
+
+        _stash = self.__stash.GetItemsFor(classifier=Variable.CLASSIFIER,
+                                          attribute=Variable.ATTR_VAR,
+                                          attributeValue="SOME.VAR.WITH.PERIODS")
+        self.assertTrue(_stash, msg="Stash has no items for SOME.VAR.WITH.PERIODS")
+
+        for x in _stash:
+            self.assertEqual(x.VarValue, '"foo"')
+            self.assertEqual(x.VarValueStripped, 'foo')
+            self.assertEqual(x.VarName, 'SOME.VAR.WITH.PERIODS')
+            self.assertEqual(x.VarNameComplete, 'SOME.VAR.WITH.PERIODS')
+            self.assertEqual(x.Raw, 'SOME.VAR.WITH.PERIODS = "foo"\n')
+            self.assertEqual(x.RawVarName, 'SOME.VAR.WITH.PERIODS')
+            self.assertEqual(x.get_items(), ["foo"])
+            self.assertEqual(x.SubItem, "")
+            self.assertEqual(x.SubItems, [])
+            self.assertEqual(x.VarOp, " = ")
+            self.assertEqual(x.Flag, "")
+            self.assertEqual(x.GetClassOverride(), "")
+
     def test_var_rdepends(self):
         from oelint_parser.cls_item import Variable
         from oelint_parser.helper_files import expand_term


### PR DESCRIPTION
Hi, I noticed that `expand_item` wasn't working properly for a specific recipe, and it turned out that what should have been a `Variable` was being regexed as `Item`.

Here's a minimum reproducible example to illustrate the issue I faced before this MR.

```
import re

regex_var = r"^(?P<varname>([A-Z0-9a-z_.-]|\$|\{|\}|:)+?)(\[(?P<ident>(\w|-|\.)+)\])*(?P<varop>(\s|\t)*(\+|\?|\:|\.)*=(\+|\.)*(\s|\t)*)(?P<varval>.*)"

test_string = "GST1.0_SRC ?= \"gitsm://github.com/nxp-imx/gstreamer.git;protocol=https\""
test_string2 = "GST10_SRC ?= \"gitsm://github.com/nxp-imx/gstreamer.git;protocol=https\""

match = re.match(regex_var, test_string)

if match:
    print("match")
    print("varname:", match.group("varname"))
    print("varopt:", match.group("varop"))
    print("varval:", match.group("varval"))
else:
    print("fail")

match = re.match(regex_var, test_string2)

if match:
    print("match")
    print("varname:", match.group("varname"))
    print("varopt:", match.group("varop"))
    print("varval:", match.group("varval"))
else:
    print("fail")
```