### PR TITLE
Set the default for the OverrideDelimiter from '_' to ':'

### DIFF
--- a/oelint_parser/cls_item.py
+++ b/oelint_parser/cls_item.py
@@ -31,7 +31,7 @@ class Item():
         self.__InFileLine = infileline
         self.__IncludedFrom = []
         self.__RealRaw = realraw or rawtext
-        self.__OverrideDelimiter = "_"
+        self.__OverrideDelimiter = ":"
 
     @property
     def Line(self):


### PR DESCRIPTION
This should create a beter report when the OverrideDelimitor could be be found.

E.g.
   .../linux-libc-headers_6.5.bb:9:error:oelint.vars.srcuriappend:Use SRC_URI_append otherwise this will override weak defaults by inherit

the SRC_URI_append will become SRC_URI:append