### PR TITLE
Add AUTHOR to known variables

### DIFF
--- a/oelint_parser/data/const-default.json
+++ b/oelint_parser/data/const-default.json
@@ -364,6 +364,7 @@
             "AS",
             "ASNEEDED",
             "ASSUME_PROVIDED",
+            "AUTHOR",
             "AUTOREV",
             "AUTO_LIBNAME_PKGS",
             "AVAILTUNES",


### PR DESCRIPTION
AUTHOR is commonly used in recipes (and even suggested by oelint-adv by default), but was missing, which resulted in `warning:oelint.vars.mispell:'AUTHOR' is unknown, maybe you meant 'AUTOREV'` errors.