### PR TITLE
Fixes/3.x

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,24 @@ for x in _stash.GetItemsFor(attribute=Variable.ATTR_VAR, attributeValue=["PV", "
     print(x.VarValueStripped)
 ```
 
+but if you need copies from a wider list to smaller lists use
+
+```python
+from oelint_parser.cls_item import Variable
+
+_all = _stash.GetItemsFor(attribute=Variable.ATTR_VAR, attributeValue=["PV", "BPV"])
+_pv = _stash.Reduce(_all, attribute=Variable.ATTR_VAR, attributeValue="PV")
+_bpv = _stash.Reduce(_all, attribute=Variable.ATTR_VAR, attributeValue="BPV")
+
+for x in _pv:
+    # variable name
+    print(x.VarName)
+    # raw unexpanded variable -> "1.0"
+    print(x.VarValue)
+    # raw unexpanded variable without quotes -> 1.0
+    print(x.VarValueStripped)
+```
+
 ### Expanding a Variable
 
 To get the effective value of a Variable after parsing you can use

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -63,6 +63,7 @@
     * [Flag](#oelint_parser.cls_item.Variable.Flag)
     * [VarOp](#oelint_parser.cls_item.Variable.VarOp)
     * [VarNameComplete](#oelint_parser.cls_item.Variable.VarNameComplete)
+    * [VarNameCompleteNoModifiers](#oelint_parser.cls_item.Variable.VarNameCompleteNoModifiers)
     * [RawVarName](#oelint_parser.cls_item.Variable.RawVarName)
     * [VarValueStripped](#oelint_parser.cls_item.Variable.VarValueStripped)
     * [IsAppend](#oelint_parser.cls_item.Variable.IsAppend)
@@ -1365,6 +1366,21 @@ def VarNameComplete() -> str
 ```
 
 Complete variable name included overrides and flags
+
+**Returns**:
+
+- `str` - complete variable name
+
+<a id="oelint_parser.cls_item.Variable.VarNameCompleteNoModifiers"></a>
+
+#### VarNameCompleteNoModifiers
+
+```python
+@property
+def VarNameCompleteNoModifiers() -> str
+```
+
+Complete variable name included overrides but without modifiers like append, prepend and remove
 
 **Returns**:
 

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -232,7 +232,7 @@ The Stash object is the central storage for extracting the bitbake information.
 ## StashList Objects
 
 ```python
-class StashList(UserList)
+class StashList(UserList[Item])
 ```
 
 Extended list of Items.
@@ -321,7 +321,12 @@ def reduce(filename: str = None,
            nolink: bool = False) -> 'Stash.StashList'
 ```
 
-Filters the list
+Filters the list.
+
+NOTE: This is a destructive operation.
+If you want to have a copy returned use
+
+Stash.Reduce(<this object>,...) instead.
 
 **Arguments**:
 

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -2197,7 +2197,7 @@ Get items
 
 **Returns**:
 
-- `list` - function name, flag, modification value
+- `list` - variable name, flag, variable operation, modification value
 
 <a id="oelint_parser.cls_item.FunctionExports"></a>
 
@@ -2770,7 +2770,7 @@ Get items
 
 **Returns**:
 
-- `list` - include name, include statement
+- `list` - parsed Class items
 
 <a id="oelint_parser.cls_item.Unset"></a>
 

--- a/oelint_parser/cls_item.py
+++ b/oelint_parser/cls_item.py
@@ -964,7 +964,7 @@ class FlagAssignment(Item):
         """Get items
 
         Returns:
-            list -- function name, flag, modification value
+            list -- variable name, flag, variable operation, modification value
         """
         return [self.VarName, self.Flag, self.VarOp, self.ValueStripped]
 
@@ -1373,7 +1373,7 @@ class Inherit(Item):
         """Get items
 
         Returns:
-            list -- include name, include statement
+            list -- parsed Class items
         """
         return self.safe_linesplit(self.__Class)
 

--- a/oelint_parser/cls_item.py
+++ b/oelint_parser/cls_item.py
@@ -389,6 +389,15 @@ class Variable(Item):
         return self.OverrideDelimiter.join([self.VarName] + self.SubItems)
 
     @property
+    def VarNameCompleteNoModifiers(self) -> str:
+        """Complete variable name included overrides but without modifiers like append, prepend and remove
+
+        Returns:
+            str: complete variable name
+        """
+        return self.OverrideDelimiter.join([self.VarName] + [x for x in self.SubItems if x not in ['prepend', 'append', 'remove']])
+
+    @property
     def RawVarName(self) -> str:
         """Variable name and flags combined
 

--- a/oelint_parser/cls_stash.py
+++ b/oelint_parser/cls_stash.py
@@ -80,7 +80,12 @@ class Stash():
                    attribute: Union[Iterable[str], str] = None,
                    attributeValue: Union[Iterable[str], str] = None,
                    nolink: bool = False) -> 'Stash.StashList':
-            """Filters the list
+            """Filters the list.
+
+            NOTE: This is a destructive operation.
+            If you want to have a copy returned use
+
+            Stash.Reduce(<this object>,...) instead.
 
             Args:
                 filename (str, optional): Full path to file. Defaults to None.

--- a/oelint_parser/cls_stash.py
+++ b/oelint_parser/cls_stash.py
@@ -381,7 +381,7 @@ class Stash():
             if item.Flag or not item.IsImmediateModify():
                 continue
             varop = item.VarOp
-            name = item.VarName
+            name = item.VarNameCompleteNoModifiers
             if name not in _exp.keys():
                 _exp[name] = None
             if varop in [" = ", " := "]:
@@ -413,7 +413,7 @@ class Stash():
             if item.IsImmediateModify():
                 continue
             varop = item.VarOp
-            name = item.VarName
+            name = item.VarNameCompleteNoModifiers
             if item.Flag:
                 continue
             if name not in _exp.keys():
@@ -436,7 +436,7 @@ class Stash():
             if item.IsImmediateModify():
                 continue
             varop = item.VarOp
-            name = item.VarName
+            name = item.VarNameCompleteNoModifiers
             if item.Flag:
                 continue
             if name not in _exp.keys():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -286,6 +286,17 @@ class OelintParserTest(unittest.TestCase):
                                                      x.VarValueStripped), "source/SOMEMORE")
             self.assertNotEqual(x.VarValueStripped, "source/SOMEMORE")
 
+    def test_expand_var(self):
+        from oelint_parser.cls_stash import Stash
+        from oelint_parser.cls_item import Variable
+
+        self.__stash = Stash()
+        self.__stash.AddFile(OelintParserTest.RECIPE)
+
+        res = self.__stash.ExpandVar(OelintParserTest.RECIPE, attribute=Variable.ATTR_VAR, attributeValue='RDEPENDS')
+
+        self.assertIn('RDEPENDS_test-recipe-test', res)
+
     def test_inlinecodeblock(self):
         from oelint_parser.cls_item import Variable
         from oelint_parser.cls_stash import Stash
@@ -546,6 +557,7 @@ class OelintParserTest(unittest.TestCase):
         for x in _stash:
             self.assertEqual(x.VarName, "A")
             self.assertEqual(x.Flag, "my-flag")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes for

- stash.ExpandVar
- ~~missing typing hint for Stash.StashList~~ (doesn't work with py 3.8)
- several docstring
- missing hint to StashList.reduce behavior
- missing documentation for Stash.Reduce