### PR TITLE
inherit: add FilePaths property

### DIFF
--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -147,6 +147,7 @@
     * [\_\_init\_\_](#oelint_parser.cls_item.Inherit.__init__)
     * [Class](#oelint_parser.cls_item.Inherit.Class)
     * [Statement](#oelint_parser.cls_item.Inherit.Statement)
+    * [FilePaths](#oelint_parser.cls_item.Inherit.FilePaths)
     * [get\_items](#oelint_parser.cls_item.Inherit.get_items)
   * [Unset](#oelint_parser.cls_item.Unset)
     * [\_\_init\_\_](#oelint_parser.cls_item.Unset.__init__)
@@ -232,7 +233,7 @@ The Stash object is the central storage for extracting the bitbake information.
 ## StashList Objects
 
 ```python
-class StashList(UserList[Item])
+class StashList(UserList)
 ```
 
 Extended list of Items.
@@ -2713,7 +2714,8 @@ def __init__(origin: str,
              statement: str,
              classes: str,
              realraw: str,
-             new_style_override_syntax: bool = False) -> None
+             new_style_override_syntax: bool = False,
+             inherit_file_paths: Set[str] = None) -> None
 ```
 
 constructor
@@ -2732,6 +2734,7 @@ constructor
 **Arguments**:
 
 - `new_style_override_syntax` _bool_ - Use ':' a override delimiter (default: {False})
+- `inherit_file_paths` _Set[str]_ - Paths of the identified inherited classes
 
 <a id="oelint_parser.cls_item.Inherit.Class"></a>
 
@@ -2762,6 +2765,25 @@ inherit statement
 **Returns**:
 
 - `str` - inherit or inherit_defer
+
+<a id="oelint_parser.cls_item.Inherit.FilePaths"></a>
+
+#### FilePaths
+
+```python
+@property
+def FilePaths() -> Set[str]
+```
+
+File paths to identified bbclasses
+
+As some classes might not be resolvable in the current context
+the order doesn't necessarily reflect the order of the
+inherit statements
+
+**Returns**:
+
+- `Set[str]` - File paths to identified bbclasses
 
 <a id="oelint_parser.cls_item.Inherit.get_items"></a>
 

--- a/oelint_parser/cls_item.py
+++ b/oelint_parser/cls_item.py
@@ -1,6 +1,6 @@
 import os
 import textwrap
-from typing import List, Tuple
+from typing import List, Set, Tuple
 
 from deprecated import deprecated
 
@@ -1332,7 +1332,9 @@ class Inherit(Item):
                  statement: str,
                  classes: str,
                  realraw: str,
-                 new_style_override_syntax: bool = False) -> None:
+                 new_style_override_syntax: bool = False,
+                 inherit_file_paths: Set[str] = None,
+                 ) -> None:
         """constructor
 
         Arguments:
@@ -1346,10 +1348,12 @@ class Inherit(Item):
 
         Keyword Arguments:
             new_style_override_syntax {bool} -- Use ':' a override delimiter (default: {False})
+            inherit_file_paths {Set[str]} -- Paths of the identified inherited classes
         """
         super().__init__(origin, line, infileline, rawtext, realraw, new_style_override_syntax)
         self.__Class = classes
         self.__Statement = statement
+        self.__FilePaths = inherit_file_paths or {}
 
     @property
     def Class(self) -> str:
@@ -1368,6 +1372,19 @@ class Inherit(Item):
             str: inherit or inherit_defer
         """
         return self.__Statement
+
+    @property
+    def FilePaths(self) -> Set[str]:
+        """File paths to identified bbclasses
+
+        As some classes might not be resolvable in the current context
+        the order doesn't necessarily reflect the order of the
+        inherit statements
+
+        Returns:
+            Set[str]: File paths to identified bbclasses
+        """
+        return self.__FilePaths
 
     def get_items(self) -> List[str]:
         """Get items

--- a/oelint_parser/parser.py
+++ b/oelint_parser/parser.py
@@ -287,6 +287,7 @@ def get_items(stash: object,
                     break
                 elif k == "inherit":
                     inhname = stash.ExpandTerm(_file, m.group("inhname"))
+                    _found_paths = set()
                     for inh_item in [x for x in inhname.split(' ') if x]:
                         if not inh_item.endswith(".bbclass"):
                             inh_item += ".bbclass"
@@ -298,6 +299,7 @@ def get_items(stash: object,
                             if _path:
                                 break
                         if _path:
+                            _found_paths.add(_path)
                             tmp = stash.AddFile(
                                 _path, lineOffset=line["line"], forcedLink=_file)
                             if any(tmp):
@@ -312,6 +314,7 @@ def get_items(stash: object,
                             m.group("inhname"),
                             line["realraw"],
                             new_style_override_syntax=override_syntax_new,
+                            inherit_file_paths=_found_paths,
                         ))
                     good = True
                     break

--- a/tests/test_bbclass.py
+++ b/tests/test_bbclass.py
@@ -3,10 +3,13 @@ import unittest
 import os
 import sys
 
+
 class OelintBBClassTest(unittest.TestCase):
 
     RECIPE = os.path.join(os.path.dirname(__file__), "testlayer/recipes-foo/recipe-foo_1.0.bb")
     RECIPE_MULTILINEINHERIT = os.path.join(os.path.dirname(__file__), "testlayer/recipes-foo/recipe-foo_2.0.bb")
+    RECIPE_WITHPATHS = os.path.join(os.path.dirname(__file__), "testlayer/recipes-foo/recipe-foo_3.0.bb")
+    RECIPE_WITHPATHS_NRES = os.path.join(os.path.dirname(__file__), "testlayer/recipes-foo/recipe-foo_3.1.bb")
     RECIPE_GLOBAL = os.path.join(os.path.dirname(__file__), "testlayer/recipes-foo/recipe-bar_1.0.bb")
     RECIPE_RECIPE = os.path.join(os.path.dirname(__file__), "testlayer/recipes-foo/recipe-baz_1.0.bb")
 
@@ -26,8 +29,8 @@ class OelintBBClassTest(unittest.TestCase):
         self.__stash = Stash()
         self.__stash.AddFile(OelintBBClassTest.RECIPE)
 
-        _stash = self.__stash.GetItemsFor(classifier=Variable.CLASSIFIER, 
-                                          attribute=Variable.ATTR_VAR, 
+        _stash = self.__stash.GetItemsFor(classifier=Variable.CLASSIFIER,
+                                          attribute=Variable.ATTR_VAR,
                                           attributeValue="FOO_A")
         self.assertTrue(_stash, msg="Stash has no items")
 
@@ -46,8 +49,8 @@ class OelintBBClassTest(unittest.TestCase):
         self.__stash = Stash()
         self.__stash.AddFile(OelintBBClassTest.RECIPE_GLOBAL)
 
-        _stash = self.__stash.GetItemsFor(classifier=Variable.CLASSIFIER, 
-                                          attribute=Variable.ATTR_VAR, 
+        _stash = self.__stash.GetItemsFor(classifier=Variable.CLASSIFIER,
+                                          attribute=Variable.ATTR_VAR,
                                           attributeValue="FOO_A")
         self.assertTrue(_stash, msg="Stash has no items")
 
@@ -66,8 +69,8 @@ class OelintBBClassTest(unittest.TestCase):
         self.__stash = Stash()
         self.__stash.AddFile(OelintBBClassTest.RECIPE_RECIPE)
 
-        _stash = self.__stash.GetItemsFor(classifier=Variable.CLASSIFIER, 
-                                          attribute=Variable.ATTR_VAR, 
+        _stash = self.__stash.GetItemsFor(classifier=Variable.CLASSIFIER,
+                                          attribute=Variable.ATTR_VAR,
                                           attributeValue="FOO_A")
         self.assertTrue(_stash, msg="Stash has no items")
 
@@ -87,7 +90,7 @@ class OelintBBClassTest(unittest.TestCase):
 
         _stash = self.__stash.GetItemsFor()
         for item in _stash:
-            self.assertFalse(item.Origin.endswith("foo-foreign.bbclass"), 
+            self.assertFalse(item.Origin.endswith("foo-foreign.bbclass"),
                              msg="A element of a non-layer bbclass was added")
 
     def test_export_functions(self):
@@ -111,8 +114,8 @@ class OelintBBClassTest(unittest.TestCase):
         self.__stash = Stash()
         self.__stash.AddFile(OelintBBClassTest.RECIPE)
 
-        _stash = self.__stash.GetItemsFor(classifier=Variable.CLASSIFIER, 
-                                          attribute=Variable.ATTR_VAR, 
+        _stash = self.__stash.GetItemsFor(classifier=Variable.CLASSIFIER,
+                                          attribute=Variable.ATTR_VAR,
                                           attributeValue="B")
         self.assertTrue(_stash, msg="Stash has no items")
         self.assertEqual(_stash[0].IsFromClass, False)
@@ -124,10 +127,42 @@ class OelintBBClassTest(unittest.TestCase):
         self.__stash = Stash()
         self.__stash.AddFile(OelintBBClassTest.RECIPE_MULTILINEINHERIT)
 
-        _stash = self.__stash.GetItemsFor(classifier=Variable.CLASSIFIER, 
-                                          attribute=Variable.ATTR_VAR, 
+        _stash = self.__stash.GetItemsFor(classifier=Variable.CLASSIFIER,
+                                          attribute=Variable.ATTR_VAR,
                                           attributeValue=["A", "B"])
         self.assertEqual(len(_stash), 2, msg="Stash has items")
 
-if __name__ == "__main__": 
+    def test_inherit_filepaths(self):
+        from oelint_parser.cls_item import Inherit
+        from oelint_parser.cls_stash import Stash
+
+        self.__stash = Stash()
+        self.__stash.AddFile(OelintBBClassTest.RECIPE_WITHPATHS)
+
+        _stash = self.__stash.GetItemsFor(classifier=Inherit.CLASSIFIER)
+
+        self.assertEqual(len(_stash), 1, msg="Stash has items")
+
+        inh_item: Inherit = _stash[0]
+
+        self.assertIn(os.path.join(os.path.dirname(__file__), "testlayer/classes/foo.bbclass"), inh_item.FilePaths)
+        self.assertIn(os.path.join(os.path.dirname(__file__), "testlayer/classes-recipe/recipe-foo.bbclass"), inh_item.FilePaths)
+
+    def test_inherit_filepaths_non_resolve(self):
+        from oelint_parser.cls_item import Inherit
+        from oelint_parser.cls_stash import Stash
+
+        self.__stash = Stash()
+        self.__stash.AddFile(OelintBBClassTest.RECIPE_WITHPATHS_NRES)
+
+        _stash = self.__stash.GetItemsFor(classifier=Inherit.CLASSIFIER)
+
+        self.assertEqual(len(_stash), 1, msg="Stash has items")
+
+        inh_item: Inherit = _stash[0]
+
+        self.assertEqual(len(inh_item.FilePaths), 0)
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/testlayer/recipes-foo/recipe-foo_3.0.bb
+++ b/tests/testlayer/recipes-foo/recipe-foo_3.0.bb
@@ -1,0 +1,1 @@
+inherit recipe-foo foo

--- a/tests/testlayer/recipes-foo/recipe-foo_3.1.bb
+++ b/tests/testlayer/recipes-foo/recipe-foo_3.1.bb
@@ -1,0 +1,1 @@
+inherit class-12 class-22


### PR DESCRIPTION
that will give back the paths of the resolvable
bbclasses in the current context as absolute paths

Closes #189