### PR TITLE
item: fix handling for special items

### DIFF
--- a/oelint_parser/cls_item.py
+++ b/oelint_parser/cls_item.py
@@ -188,6 +188,8 @@ class Item():
         """
         if ":" in name:
             self.__OverrideDelimiter = ":"
+        if any(name.startswith(x) for x in ['SRCREV_']):
+            self.__OverrideDelimiter = "_"
         chunks = name.split(self.__OverrideDelimiter)
         _suffix = []
         _var = [chunks[0]]
@@ -220,6 +222,8 @@ class Item():
         if ":" in name:
             self.__OverrideDelimiter = ":"
         chunks = name.split(self.__OverrideDelimiter)
+        if name in ['__anonymous']:
+            return (name, '')
         _marker = ["append", "prepend", "class-native",
                    "class-cross", "class-target", "remove"]
         _suffix = []

--- a/tests/test-recipe-new_1.0.bb
+++ b/tests/test-recipe-new_1.0.bb
@@ -12,3 +12,5 @@ do_example:prepend:qemux86-64:poky() {
 RDEPENDS:${PN}-test += "foo"
 
 Y = "${P}"
+
+SRCREV_foo = "abcd"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -232,12 +232,12 @@ class OelintParserTest(unittest.TestCase):
         _stash = self.__stash.GetItemsFor(classifier=Function.CLASSIFIER)
         self.assertTrue(_stash, msg="Stash has no items")
 
-        _filteredStash = [x for x in _stash if x.FuncName in ["", "anonymous"]]
+        _filteredStash = [x for x in _stash if x.FuncName in ["", "__anonymous"]]
         self.assertEqual(len(_filteredStash), 3)
 
         for item in _filteredStash:
             self.assertEqual(item.IsPython, True)
-            self.assertIn(item.FuncName, ["", "anonymous"])
+            self.assertIn(item.FuncName, ["", "__anonymous"])
 
     def test_varflag(self):
         from oelint_parser.cls_item import FlagAssignment

--- a/tests/test_parser_new.py
+++ b/tests/test_parser_new.py
@@ -178,6 +178,19 @@ class OelintParserTestNew(unittest.TestCase):
             self.assertEqual(x.IsNewStyleOverrideSyntax, True)
             self.assertEqual(x.OverrideDelimiter, ':')
 
+    def test_srcrev_parsing(self):
+        from oelint_parser.cls_stash import Stash
+        from oelint_parser.cls_item import Variable
+
+        self.__stash = Stash()
+        self.__stash.AddFile(OelintParserTestNew.RECIPE)
+
+        _stash = self.__stash.GetItemsFor(classifier=Variable.CLASSIFIER, attribute=Variable.ATTR_VAR, attributeValue='SRCREV')
+        self.assertTrue(_stash, msg="Stash has items")
+        for x in _stash:
+            self.assertEqual(x.SubItems, ['foo'])
+            self.assertEqual(x.OverrideDelimiter, '_')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
such as SRCREV which is still using '_' even with the newer override delimiter.
And for __anonymous functions - with the older
override syntax it would be trimmed down to
'anonymous' which is wrong