### PR TITLE
stash: fix nested includes

### DIFF
--- a/oelint_parser/cls_stash.py
+++ b/oelint_parser/cls_stash.py
@@ -150,6 +150,7 @@ class Stash():
             self.__map[forcedLink].append(_file)
             if _file not in self.__map:
                 self.__map[_file] = []
+            self.__map[_file].append(forcedLink)
         # Match bbappends to bbs
         if _file.endswith(".bbappend"):
             bn_this = os.path.basename(_file).replace(


### PR DESCRIPTION
Make sure the forced link is included in stash, otherwise nested includes report various errors. Example of failing test:

test_1.0.bb:
"
require test-top.inc
"

test-top.inc:
"
require test-nested.inc
"

test-nested.inc:
"
LICENSE = "GPL-2.0-only"
"

Validation of test_1.0.bb reports the following, even if LICENSE is clearly set in test-nested.inc and therefore also set in test_1.0.bb:
"
test_1.0.bb:1:error:oelint.var.mandatoryvar.LICENSE:Variable 'LICENSE' should be set
"

@priv-kweihmann I am not sure if this is the correct fix for the issue.