### PR TITLE
ci: move to python-build

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -18,13 +18,13 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade pip build
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
     - name: Lint
       run: flake8
     - name: Build
-      run: python3 setup.py build
+      run: python3 -m build --sdist --wheel
     - name: Test
       run: pytest
     - name: Doc gen


### PR DESCRIPTION
as directly calling setup.py is deprecated