### PR TITLE
item: better append detection

### DIFF
--- a/oelint_parser/cls_item.py
+++ b/oelint_parser/cls_item.py
@@ -399,7 +399,7 @@ class Variable(Item):
         Returns:
             bool -- True is variable is appended
         """
-        return self.VarOp in [" += ", " =+ ", " =. ", " .= "] or "append" in self.SubItems or "prepend" in self.SubItems
+        return self.VarOp.strip() in ["+=", "=+", "=.", ".="] or "append" in self.SubItems or "prepend" in self.SubItems
 
     def AppendOperation(self) -> List[str]:
         """Get variable modifiers
@@ -408,7 +408,7 @@ class Variable(Item):
             list -- list could contain any combination of 'append', ' += ', 'prepend' and 'remove'
         """
         res = []
-        if self.VarOp in [" += ", " .= ", " =+ ", " =. "]:
+        if self.VarOp.strip() in ["+=", ".=", "=+", "=."]:
             res.append(self.VarOp)
         if "append" in self.SubItems:
             res.append("append")

--- a/tests/test-recipe-new_1.0.bb
+++ b/tests/test-recipe-new_1.0.bb
@@ -14,3 +14,5 @@ RDEPENDS:${PN}-test += "foo"
 Y = "${P}"
 
 SRCREV_foo = "abcd"
+
+C  += "1"

--- a/tests/test_parser_new.py
+++ b/tests/test_parser_new.py
@@ -191,6 +191,21 @@ class OelintParserTestNew(unittest.TestCase):
             self.assertEqual(x.SubItems, ['foo'])
             self.assertEqual(x.OverrideDelimiter, '_')
 
+    def test_var_isappend(self):
+        from oelint_parser.cls_item import Variable
+        from oelint_parser.cls_stash import Stash
+
+        self.__stash = Stash()
+        self.__stash.AddFile(OelintParserTestNew.RECIPE)
+
+        _stash = self.__stash.GetItemsFor(classifier=Variable.CLASSIFIER,
+                                          attribute=Variable.ATTR_VAR,
+                                          attributeValue="C")
+        self.assertTrue(_stash, msg="Stash has items")
+        for x in _stash:
+            self.assertEqual(x.IsAppend(), True)
+            self.assertIn('  += ', x.AppendOperation())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
to allow operations even with tiny off standard syntax issues like `  += `.

Relates to priv-kweihmann/oelint-adv#563