### PR TITLE
stash: add fingerprint

### DIFF
--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -6,6 +6,7 @@
     * [StashList](#oelint_parser.cls_stash.Stash.StashList)
     * [\_\_init\_\_](#oelint_parser.cls_stash.Stash.__init__)
     * [AddFile](#oelint_parser.cls_stash.Stash.AddFile)
+    * [FingerPrint](#oelint_parser.cls_stash.Stash.FingerPrint)
     * [Append](#oelint_parser.cls_stash.Stash.Append)
     * [Remove](#oelint_parser.cls_stash.Stash.Remove)
     * [AddDistroMachineFromLayer](#oelint_parser.cls_stash.Stash.AddDistroMachineFromLayer)
@@ -30,60 +31,11 @@
     * [GetValidNamedResources](#oelint_parser.cls_stash.Stash.GetValidNamedResources)
     * [IsImage](#oelint_parser.cls_stash.Stash.IsImage)
     * [IsPackageGroup](#oelint_parser.cls_stash.Stash.IsPackageGroup)
-* [oelint\_parser.rpl\_regex](#oelint_parser.rpl_regex)
-  * [RegexRpl](#oelint_parser.rpl_regex.RegexRpl)
-    * [search](#oelint_parser.rpl_regex.RegexRpl.search)
-    * [split](#oelint_parser.rpl_regex.RegexRpl.split)
-    * [match](#oelint_parser.rpl_regex.RegexRpl.match)
-    * [sub](#oelint_parser.rpl_regex.RegexRpl.sub)
-    * [finditer](#oelint_parser.rpl_regex.RegexRpl.finditer)
-* [oelint\_parser.inlinerep](#oelint_parser.inlinerep)
-  * [bb\_utils\_filter](#oelint_parser.inlinerep.bb_utils_filter)
-  * [bb\_utils\_contains](#oelint_parser.inlinerep.bb_utils_contains)
-  * [bb\_utils\_contains\_any](#oelint_parser.inlinerep.bb_utils_contains_any)
-  * [oe\_utils\_conditional](#oelint_parser.inlinerep.oe_utils_conditional)
-  * [oe\_utils\_ifelse](#oelint_parser.inlinerep.oe_utils_ifelse)
-  * [oe\_utils\_any\_distro\_features](#oelint_parser.inlinerep.oe_utils_any_distro_features)
-  * [oe\_utils\_all\_distro\_features](#oelint_parser.inlinerep.oe_utils_all_distro_features)
-  * [oe\_utils\_vartrue](#oelint_parser.inlinerep.oe_utils_vartrue)
-  * [oe\_utils\_less\_or\_equal](#oelint_parser.inlinerep.oe_utils_less_or_equal)
-  * [oe\_utils\_version\_less\_or\_equal](#oelint_parser.inlinerep.oe_utils_version_less_or_equal)
-  * [oe\_utils\_both\_contain](#oelint_parser.inlinerep.oe_utils_both_contain)
-  * [inlinerep](#oelint_parser.inlinerep.inlinerep)
-* [oelint\_parser.helper\_files](#oelint_parser.helper_files)
-  * [get\_files](#oelint_parser.helper_files.get_files)
-  * [get\_layer\_root](#oelint_parser.helper_files.get_layer_root)
-  * [find\_local\_or\_in\_layer](#oelint_parser.helper_files.find_local_or_in_layer)
-  * [get\_scr\_components](#oelint_parser.helper_files.get_scr_components)
-  * [safe\_linesplit](#oelint_parser.helper_files.safe_linesplit)
-  * [guess\_recipe\_name](#oelint_parser.helper_files.guess_recipe_name)
-  * [guess\_base\_recipe\_name](#oelint_parser.helper_files.guess_base_recipe_name)
-  * [guess\_recipe\_version](#oelint_parser.helper_files.guess_recipe_version)
-  * [expand\_term](#oelint_parser.helper_files.expand_term)
-  * [get\_valid\_package\_names](#oelint_parser.helper_files.get_valid_package_names)
-  * [get\_valid\_named\_resources](#oelint_parser.helper_files.get_valid_named_resources)
-  * [is\_image](#oelint_parser.helper_files.is_image)
-  * [is\_packagegroup](#oelint_parser.helper_files.is_packagegroup)
-* [oelint\_parser.constants](#oelint_parser.constants)
-  * [Constants](#oelint_parser.constants.Constants)
-    * [GetByPath](#oelint_parser.constants.Constants.GetByPath)
-    * [AddConstants](#oelint_parser.constants.Constants.AddConstants)
-    * [RemoveConstants](#oelint_parser.constants.Constants.RemoveConstants)
-    * [OverrideConstants](#oelint_parser.constants.Constants.OverrideConstants)
-    * [FunctionsKnown](#oelint_parser.constants.Constants.FunctionsKnown)
-    * [FunctionsOrder](#oelint_parser.constants.Constants.FunctionsOrder)
-    * [VariablesMandatory](#oelint_parser.constants.Constants.VariablesMandatory)
-    * [VariablesSuggested](#oelint_parser.constants.Constants.VariablesSuggested)
-    * [MirrorsKnown](#oelint_parser.constants.Constants.MirrorsKnown)
-    * [VariablesProtected](#oelint_parser.constants.Constants.VariablesProtected)
-    * [VariablesProtectedAppend](#oelint_parser.constants.Constants.VariablesProtectedAppend)
-    * [VariablesOrder](#oelint_parser.constants.Constants.VariablesOrder)
-    * [VariablesKnown](#oelint_parser.constants.Constants.VariablesKnown)
-    * [DistrosKnown](#oelint_parser.constants.Constants.DistrosKnown)
-    * [MachinesKnown](#oelint_parser.constants.Constants.MachinesKnown)
-    * [ImagesClasses](#oelint_parser.constants.Constants.ImagesClasses)
-    * [ImagesVariables](#oelint_parser.constants.Constants.ImagesVariables)
-    * [SetsBase](#oelint_parser.constants.Constants.SetsBase)
+* [oelint\_parser.parser](#oelint_parser.parser)
+  * [get\_full\_scope](#oelint_parser.parser.get_full_scope)
+  * [prepare\_lines\_subparser](#oelint_parser.parser.prepare_lines_subparser)
+  * [prepare\_lines](#oelint_parser.parser.prepare_lines)
+  * [get\_items](#oelint_parser.parser.get_items)
 * [oelint\_parser.cls\_item](#oelint_parser.cls_item)
   * [Item](#oelint_parser.cls_item.Item)
     * [\_\_init\_\_](#oelint_parser.cls_item.Item.__init__)
@@ -203,11 +155,60 @@
     * [VarName](#oelint_parser.cls_item.Unset.VarName)
     * [Flag](#oelint_parser.cls_item.Unset.Flag)
     * [get\_items](#oelint_parser.cls_item.Unset.get_items)
-* [oelint\_parser.parser](#oelint_parser.parser)
-  * [get\_full\_scope](#oelint_parser.parser.get_full_scope)
-  * [prepare\_lines\_subparser](#oelint_parser.parser.prepare_lines_subparser)
-  * [prepare\_lines](#oelint_parser.parser.prepare_lines)
-  * [get\_items](#oelint_parser.parser.get_items)
+* [oelint\_parser.helper\_files](#oelint_parser.helper_files)
+  * [get\_files](#oelint_parser.helper_files.get_files)
+  * [get\_layer\_root](#oelint_parser.helper_files.get_layer_root)
+  * [find\_local\_or\_in\_layer](#oelint_parser.helper_files.find_local_or_in_layer)
+  * [get\_scr\_components](#oelint_parser.helper_files.get_scr_components)
+  * [safe\_linesplit](#oelint_parser.helper_files.safe_linesplit)
+  * [guess\_recipe\_name](#oelint_parser.helper_files.guess_recipe_name)
+  * [guess\_base\_recipe\_name](#oelint_parser.helper_files.guess_base_recipe_name)
+  * [guess\_recipe\_version](#oelint_parser.helper_files.guess_recipe_version)
+  * [expand\_term](#oelint_parser.helper_files.expand_term)
+  * [get\_valid\_package\_names](#oelint_parser.helper_files.get_valid_package_names)
+  * [get\_valid\_named\_resources](#oelint_parser.helper_files.get_valid_named_resources)
+  * [is\_image](#oelint_parser.helper_files.is_image)
+  * [is\_packagegroup](#oelint_parser.helper_files.is_packagegroup)
+* [oelint\_parser.rpl\_regex](#oelint_parser.rpl_regex)
+  * [RegexRpl](#oelint_parser.rpl_regex.RegexRpl)
+    * [search](#oelint_parser.rpl_regex.RegexRpl.search)
+    * [split](#oelint_parser.rpl_regex.RegexRpl.split)
+    * [match](#oelint_parser.rpl_regex.RegexRpl.match)
+    * [sub](#oelint_parser.rpl_regex.RegexRpl.sub)
+    * [finditer](#oelint_parser.rpl_regex.RegexRpl.finditer)
+* [oelint\_parser.constants](#oelint_parser.constants)
+  * [Constants](#oelint_parser.constants.Constants)
+    * [GetByPath](#oelint_parser.constants.Constants.GetByPath)
+    * [AddConstants](#oelint_parser.constants.Constants.AddConstants)
+    * [RemoveConstants](#oelint_parser.constants.Constants.RemoveConstants)
+    * [OverrideConstants](#oelint_parser.constants.Constants.OverrideConstants)
+    * [FunctionsKnown](#oelint_parser.constants.Constants.FunctionsKnown)
+    * [FunctionsOrder](#oelint_parser.constants.Constants.FunctionsOrder)
+    * [VariablesMandatory](#oelint_parser.constants.Constants.VariablesMandatory)
+    * [VariablesSuggested](#oelint_parser.constants.Constants.VariablesSuggested)
+    * [MirrorsKnown](#oelint_parser.constants.Constants.MirrorsKnown)
+    * [VariablesProtected](#oelint_parser.constants.Constants.VariablesProtected)
+    * [VariablesProtectedAppend](#oelint_parser.constants.Constants.VariablesProtectedAppend)
+    * [VariablesOrder](#oelint_parser.constants.Constants.VariablesOrder)
+    * [VariablesKnown](#oelint_parser.constants.Constants.VariablesKnown)
+    * [DistrosKnown](#oelint_parser.constants.Constants.DistrosKnown)
+    * [MachinesKnown](#oelint_parser.constants.Constants.MachinesKnown)
+    * [ImagesClasses](#oelint_parser.constants.Constants.ImagesClasses)
+    * [ImagesVariables](#oelint_parser.constants.Constants.ImagesVariables)
+    * [SetsBase](#oelint_parser.constants.Constants.SetsBase)
+* [oelint\_parser.inlinerep](#oelint_parser.inlinerep)
+  * [bb\_utils\_filter](#oelint_parser.inlinerep.bb_utils_filter)
+  * [bb\_utils\_contains](#oelint_parser.inlinerep.bb_utils_contains)
+  * [bb\_utils\_contains\_any](#oelint_parser.inlinerep.bb_utils_contains_any)
+  * [oe\_utils\_conditional](#oelint_parser.inlinerep.oe_utils_conditional)
+  * [oe\_utils\_ifelse](#oelint_parser.inlinerep.oe_utils_ifelse)
+  * [oe\_utils\_any\_distro\_features](#oelint_parser.inlinerep.oe_utils_any_distro_features)
+  * [oe\_utils\_all\_distro\_features](#oelint_parser.inlinerep.oe_utils_all_distro_features)
+  * [oe\_utils\_vartrue](#oelint_parser.inlinerep.oe_utils_vartrue)
+  * [oe\_utils\_less\_or\_equal](#oelint_parser.inlinerep.oe_utils_less_or_equal)
+  * [oe\_utils\_version\_less\_or\_equal](#oelint_parser.inlinerep.oe_utils_version_less_or_equal)
+  * [oe\_utils\_both\_contain](#oelint_parser.inlinerep.oe_utils_both_contain)
+  * [inlinerep](#oelint_parser.inlinerep.inlinerep)
 
 <a id="oelint_parser"></a>
 
@@ -387,6 +388,21 @@ Adds a file to the stash
 **Returns**:
 
 - `list` - List of {oelint_parser.cls_item.Item}
+
+<a id="oelint_parser.cls_stash.Stash.FingerPrint"></a>
+
+#### FingerPrint
+
+```python
+@property
+def FingerPrint() -> str
+```
+
+Get the SHA1 fingerprint of the current Stash
+
+**Returns**:
+
+- `str` - hexdigest checksum
 
 <a id="oelint_parser.cls_stash.Stash.Append"></a>
 
@@ -854,943 +870,110 @@ returns if the file is likely a packagegroup recipe or not
 
 - `bool` - True if _file is a packagegroup recipe
 
-<a id="oelint_parser.rpl_regex"></a>
+<a id="oelint_parser.parser"></a>
 
-# oelint\_parser.rpl\_regex
+# oelint\_parser.parser
 
-<a id="oelint_parser.rpl_regex.RegexRpl"></a>
+<a id="oelint_parser.parser.get_full_scope"></a>
 
-## RegexRpl Objects
-
-```python
-class RegexRpl()
-```
-
-Safe regex replacements
-
-<a id="oelint_parser.rpl_regex.RegexRpl.search"></a>
-
-#### search
+#### get\_full\_scope
 
 ```python
-@staticmethod
-def search(pattern: str,
-           string: str,
-           timeout: int = 5,
-           default: object = None,
-           **kwargs) -> Union[Match, None]
+def get_full_scope(_string: str, offset: int, _sstart: int, _send: int) -> str
 ```
 
-replacement for re.search
+get full block of an inline statement
 
 **Arguments**:
 
-- `pattern` _str_ - regex pattern
-- `string` _str_ - input string
-- `timeout` _int, optional_ - Timeout for operation. On timeout `default` will be returned. Defaults to 5.
-- `default` __type_, optional_ - Default to return on timeout. Defaults to None.
+- `_string` _str_ - input string
+- `offset` _int_ - offset in string
+- `_sstart` _int_ - block start index
+- `_send` _int_ - block end index
   
 
 **Returns**:
 
-- `Match` - Match object or None
+- `str` - full block on inline statement
 
-<a id="oelint_parser.rpl_regex.RegexRpl.split"></a>
+<a id="oelint_parser.parser.prepare_lines_subparser"></a>
 
-#### split
+#### prepare\_lines\_subparser
 
 ```python
-@staticmethod
-def split(pattern: str,
-          string: str,
-          timeout: int = 5,
-          default: object = None,
-          **kwargs) -> List[str]
+def prepare_lines_subparser(_iter: Iterable,
+                            lineOffset: int,
+                            num: int,
+                            line: int,
+                            raw_line: str = None,
+                            negative: bool = False) -> List[str]
 ```
 
-replacement for re.split
+preprocess raw input
 
 **Arguments**:
 
-- `pattern` _str_ - regex pattern
-- `string` _str_ - input string
-- `timeout` _int, optional_ - Timeout for operation. On timeout `default` will be returned. Defaults to 5.
-- `default` __type_, optional_ - Default to return on timeout. Defaults to None.
+- `_iter` _iterator_ - line interator object
+- `lineOffset` _int_ - current line index
+- `num` _int_ - internal line counter
+- `line` _int_ - input string
+- `raw_line` _string, optional_ - internal line representation. Defaults to None.
+- `negative` _bool_ - Negative branch inline expansion. Defaults to False
   
 
 **Returns**:
 
-- `list` - list object or None
+- `list` - list of preproccessed chunks
 
-<a id="oelint_parser.rpl_regex.RegexRpl.match"></a>
+<a id="oelint_parser.parser.prepare_lines"></a>
 
-#### match
+#### prepare\_lines
 
 ```python
-@staticmethod
-def match(pattern: str,
-          string: str,
-          timeout: int = 5,
-          default: object = None,
-          **kwargs) -> Union[Match, None]
+def prepare_lines(_file: str,
+                  lineOffset: int = 0,
+                  negative: bool = False) -> List[str]
 ```
 
-replacement for re.match
+break raw file input into preprocessed chunks
 
 **Arguments**:
 
-- `pattern` _str_ - regex pattern
-- `string` _str_ - input string
-- `timeout` _int, optional_ - Timeout for operation. On timeout `default` will be returned. Defaults to 5.
-- `default` __type_, optional_ - Default to return on timeout. Defaults to None.
+- `_file` _string_ - Full path to file
+- `lineOffset` _int, optional_ - line offset counter. Defaults to 0.
+- `negative` _bool_ - Negative branch inline expansion. Defaults to False
   
 
 **Returns**:
 
-- `Match` - Match object or None
+- `list` - preprocessed list of chunks
 
-<a id="oelint_parser.rpl_regex.RegexRpl.sub"></a>
+<a id="oelint_parser.parser.get_items"></a>
 
-#### sub
+#### get\_items
 
 ```python
-@staticmethod
-def sub(pattern: str,
-        repl: str,
-        string: str,
-        timeout: int = 5,
-        default: str = '',
-        **kwargs) -> str
+def get_items(stash: object,
+              _file: str,
+              lineOffset: int = 0,
+              new_style_override_syntax: bool = False,
+              negative: bool = False) -> List[Item]
 ```
 
-replacement for re.sub
+parses file
 
 **Arguments**:
 
-- `pattern` _str_ - regex pattern
-- `repl` _str_ - replacement string
-- `string` _str_ - input string
-- `timeout` _int, optional_ - Timeout for operation. On timeout `default` will be returned. Defaults to 5.
-- `default` __type_, optional_ - Default to return on timeout. Defaults to ''.
+- `stash` _oelint_parser.cls_stash.Stash_ - Stash object
+- `_file` _string_ - Full path to file
+- `lineOffset` _int, optional_ - line offset counter. Defaults to 0.
+- `new_style_override_syntax` _bool, optional_ - default to new override syntax (default: False)
+- `negative` _bool, optional_ - Negative branch inline expansion (default: False)
   
 
 **Returns**:
 
-- `str` - string
-
-<a id="oelint_parser.rpl_regex.RegexRpl.finditer"></a>
-
-#### finditer
-
-```python
-@staticmethod
-def finditer(pattern: str,
-             string: str,
-             timeout: int = 5,
-             default: object = None,
-             **kwargs) -> Scanner
-```
-
-replacement for re.finditer
-
-**Arguments**:
-
-- `pattern` _str_ - regex pattern
-- `string` _str_ - input string
-- `timeout` _int, optional_ - Timeout for operation. On timeout `default` will be returned. Defaults to 5.
-- `default` __type_, optional_ - Default to return on timeout. Defaults to None.
-  
-
-**Returns**:
-
-- `Scanner` - Scanner object or None
-
-<a id="oelint_parser.inlinerep"></a>
-
-# oelint\_parser.inlinerep
-
-<a id="oelint_parser.inlinerep.bb_utils_filter"></a>
-
-#### bb\_utils\_filter
-
-```python
-def bb_utils_filter(_in: str, negative_clause: bool = False) -> str
-```
-
-bb.utils.filter emulation
-
-**Arguments**:
-
-- `_in` _str_ - Input string
-- `negative_clause` _bool_ - return negative branch
-  
-
-**Returns**:
-
-- `str` - True argument of the conditional or None if not applicable
-
-<a id="oelint_parser.inlinerep.bb_utils_contains"></a>
-
-#### bb\_utils\_contains
-
-```python
-def bb_utils_contains(_in: str, negative_clause: bool = False) -> str
-```
-
-bb.utils.contains emulation
-
-**Arguments**:
-
-- `_in` _str_ - Input string
-- `negative_clause` _bool_ - return negative branch
-  
-
-**Returns**:
-
-- `str` - True argument of the conditional or None if not applicable
-
-<a id="oelint_parser.inlinerep.bb_utils_contains_any"></a>
-
-#### bb\_utils\_contains\_any
-
-```python
-def bb_utils_contains_any(_in: str, negative_clause: bool = False) -> str
-```
-
-bb.utils.contains_any emulation
-
-**Arguments**:
-
-- `_in` _str_ - Input string
-- `negative_clause` _bool_ - return negative branch
-  
-
-**Returns**:
-
-- `str` - True argument of the conditional or None if not applicable
-
-<a id="oelint_parser.inlinerep.oe_utils_conditional"></a>
-
-#### oe\_utils\_conditional
-
-```python
-def oe_utils_conditional(_in: str, negative_clause: bool = False) -> str
-```
-
-oe.utils.conditional emulation
-
-**Arguments**:
-
-- `_in` _str_ - Input string
-- `negative_clause` _bool_ - return negative branch
-  
-
-**Returns**:
-
-- `str` - True argument of the conditional or None if not applicable
-
-<a id="oelint_parser.inlinerep.oe_utils_ifelse"></a>
-
-#### oe\_utils\_ifelse
-
-```python
-def oe_utils_ifelse(_in: str, negative_clause: bool = False) -> str
-```
-
-oe.utils.ifelse emulation
-
-**Arguments**:
-
-- `_in` _str_ - Input string
-- `negative_clause` _bool_ - return negative branch
-  
-
-**Returns**:
-
-- `str` - True argument of the conditional or None if not applicable
-
-<a id="oelint_parser.inlinerep.oe_utils_any_distro_features"></a>
-
-#### oe\_utils\_any\_distro\_features
-
-```python
-def oe_utils_any_distro_features(_in: str,
-                                 negative_clause: bool = False) -> str
-```
-
-oe.utils.any_distro_features emulation
-
-**Arguments**:
-
-- `_in` _str_ - Input string
-- `negative_clause` _bool_ - return negative branch
-  
-
-**Returns**:
-
-- `str` - True argument of the conditional or None if not applicable
-
-<a id="oelint_parser.inlinerep.oe_utils_all_distro_features"></a>
-
-#### oe\_utils\_all\_distro\_features
-
-```python
-def oe_utils_all_distro_features(_in: str,
-                                 negative_clause: bool = False) -> str
-```
-
-oe.utils.all_distro_features emulation
-
-**Arguments**:
-
-- `_in` _str_ - Input string
-- `negative_clause` _bool_ - return negative branch
-  
-
-**Returns**:
-
-- `str` - True argument of the conditional or None if not applicable
-
-<a id="oelint_parser.inlinerep.oe_utils_vartrue"></a>
-
-#### oe\_utils\_vartrue
-
-```python
-def oe_utils_vartrue(_in: str, negative_clause: bool = False) -> str
-```
-
-oe.utils.vartrue emulation
-
-**Arguments**:
-
-- `_in` _str_ - Input string
-- `negative_clause` _bool_ - return negative branch
-  
-
-**Returns**:
-
-- `str` - True argument of the conditional or None if not applicable
-
-<a id="oelint_parser.inlinerep.oe_utils_less_or_equal"></a>
-
-#### oe\_utils\_less\_or\_equal
-
-```python
-def oe_utils_less_or_equal(_in: str, negative_clause: bool = False) -> str
-```
-
-oe.utils.less_or_equal emulation
-
-**Arguments**:
-
-- `_in` _str_ - Input string
-- `negative_clause` _bool_ - return negative branch
-  
-
-**Returns**:
-
-- `str` - True argument of the conditional or None if not applicable
-
-<a id="oelint_parser.inlinerep.oe_utils_version_less_or_equal"></a>
-
-#### oe\_utils\_version\_less\_or\_equal
-
-```python
-def oe_utils_version_less_or_equal(_in: str,
-                                   negative_clause: bool = False) -> str
-```
-
-oe.utils.version_less_or_equal emulation
-
-**Arguments**:
-
-- `_in` _str_ - Input string
-- `negative_clause` _bool_ - return negative branch
-  
-
-**Returns**:
-
-- `str` - True argument of the conditional or None if not applicable
-
-<a id="oelint_parser.inlinerep.oe_utils_both_contain"></a>
-
-#### oe\_utils\_both\_contain
-
-```python
-def oe_utils_both_contain(_in: str, negative_clause: bool = False) -> str
-```
-
-oe.utils.both_contain emulation
-
-**Arguments**:
-
-- `_in` _str_ - Input string
-- `negative_clause` _bool_ - return negative branch
-  
-
-**Returns**:
-
-- `str` - True argument of the conditional or None if not applicable
-
-<a id="oelint_parser.inlinerep.inlinerep"></a>
-
-#### inlinerep
-
-```python
-def inlinerep(_in: str, negative_clause: bool = False) -> str
-```
-
-Replaces inline code expressions
-
-**Arguments**:
-
-- `_in` _str_ - Input string
-- `negative_clause` _bool_ - return negative branch
-  
-
-**Returns**:
-
-- `str` - Expanded string or None, if not applicable
-
-<a id="oelint_parser.helper_files"></a>
-
-# oelint\_parser.helper\_files
-
-<a id="oelint_parser.helper_files.get_files"></a>
-
-#### get\_files
-
-```python
-@deprecated(version='3.0.0', reason='Use Stash.GetFiles instead')
-def get_files(stash: Stash, *args, **kwargs)
-```
-
-Legacy interface get_files.
-
-Use Stash.GetFiles instead.
-
-**Arguments**:
-
-- `stash` _Stash_ - Stash object
-  
-
-**Returns**:
-
-- `Stash.GetFiles` - .
-
-<a id="oelint_parser.helper_files.get_layer_root"></a>
-
-#### get\_layer\_root
-
-```python
-@deprecated(version='3.0.0', reason='Use Stash.GetLayerRoot instead')
-def get_layer_root(*args, **kwargs)
-```
-
-Legacy interface get_layer_root
-
-Use Stash.GetLayerRoot instead.
-
-**Returns**:
-
-- `Stash.GetLayerRoot` - .
-
-<a id="oelint_parser.helper_files.find_local_or_in_layer"></a>
-
-#### find\_local\_or\_in\_layer
-
-```python
-@deprecated(version='3.0.0', reason='Use Stash.FindLocalOrLayer instead')
-def find_local_or_in_layer(*args, **kwargs)
-```
-
-Legacy interface find_local_or_in_layer
-
-Use Stash.FindLocalOrLayer instead.
-
-**Returns**:
-
-- `Stash.FindLocalOrLayer` - .
-
-<a id="oelint_parser.helper_files.get_scr_components"></a>
-
-#### get\_scr\_components
-
-```python
-@deprecated(version='3.0.0', reason='Use Stash.GetScrComponents instead')
-def get_scr_components(*args, **kwargs)
-```
-
-Legacy interface get_scr_components
-
-Use Stash.GetScrComponents instead
-
-**Returns**:
-
-- `Stash.GetScrComponents` - .
-
-<a id="oelint_parser.helper_files.safe_linesplit"></a>
-
-#### safe\_linesplit
-
-```python
-@deprecated(version='3.0.0', reason='Use Stash.SafeLineSplit instead')
-def safe_linesplit(*args, **kwargs)
-```
-
-Legacy interface safe_linesplit
-
-Use Stash.SafeLineSplit instead
-
-**Returns**:
-
-- `Stash.SafeLineSplit` - .
-
-<a id="oelint_parser.helper_files.guess_recipe_name"></a>
-
-#### guess\_recipe\_name
-
-```python
-@deprecated(version='3.0.0', reason='Use Stash.GuessRecipeName instead')
-def guess_recipe_name(*args, **kwargs)
-```
-
-Legacy interface guess_recipe_name
-
-Use Stash.GuessRecipeName instead
-
-**Returns**:
-
-- `Stash.GuessBaseRecipeName` - .
-
-<a id="oelint_parser.helper_files.guess_base_recipe_name"></a>
-
-#### guess\_base\_recipe\_name
-
-```python
-@deprecated(version='3.0.0', reason='Use Stash.GuessBaseRecipeName instead')
-def guess_base_recipe_name(*args, **kwargs)
-```
-
-Legacy interface guess_base_recipe_name
-
-Use Stash.GuessBaseRecipeName instead
-
-**Returns**:
-
-- `Stash.GuessBaseRecipeName` - .
-
-<a id="oelint_parser.helper_files.guess_recipe_version"></a>
-
-#### guess\_recipe\_version
-
-```python
-@deprecated(version='3.0.0', reason='Use Stash.GuessRecipeVersion instead')
-def guess_recipe_version(*args, **kwargs)
-```
-
-Legacy interface guess_recipe_version
-
-Use Stash.GuessRecipeVersion instead
-
-**Returns**:
-
-- `Stash.GuessRecipeVersion` - .
-
-<a id="oelint_parser.helper_files.expand_term"></a>
-
-#### expand\_term
-
-```python
-@deprecated(version='3.0.0', reason='Use Stash.ExpandTerm instead')
-def expand_term(stash: Stash, *args, **kwargs)
-```
-
-Legacy interface expand_term
-
-Use Stash.ExpandTerm instead
-
-**Arguments**:
-
-- `stash` _Stash_ - Stash object
-  
-
-**Returns**:
-
-- `Stash.ExpandTerm` - .
-
-<a id="oelint_parser.helper_files.get_valid_package_names"></a>
-
-#### get\_valid\_package\_names
-
-```python
-@deprecated(version='3.0.0', reason='Use Stash.GetValidPackageNames instead')
-def get_valid_package_names(stash: Stash, *args, **kwargs)
-```
-
-Legacy interface get_valid_package_names
-
-Use Stash.GetValidPackageNames instead
-
-**Arguments**:
-
-- `stash` _Stash_ - Stash object
-  
-
-**Returns**:
-
-- `Stash.GetValidPackageNames` - .
-
-<a id="oelint_parser.helper_files.get_valid_named_resources"></a>
-
-#### get\_valid\_named\_resources
-
-```python
-@deprecated(version='3.0.0', reason='Use Stash.GetValidNamedResources instead')
-def get_valid_named_resources(stash: Stash, *args, **kwargs)
-```
-
-Legacy interface get_valid_named_resources
-
-Use Stash.GetValidNamedResources instead
-
-**Arguments**:
-
-- `stash` _Stash_ - Stash object
-  
-
-**Returns**:
-
-- `Stash.GetValidNamedResources` - .
-
-<a id="oelint_parser.helper_files.is_image"></a>
-
-#### is\_image
-
-```python
-@deprecated(version='3.0.0', reason='Use Stash.IsImage instead')
-def is_image(stash: Stash, *args, **kwargs)
-```
-
-Legacy interface is_image
-
-Use Stash.IsImage instead
-
-**Arguments**:
-
-- `stash` _Stash_ - Stash object
-  
-
-**Returns**:
-
-- `Stash.IsImage` - .
-
-<a id="oelint_parser.helper_files.is_packagegroup"></a>
-
-#### is\_packagegroup
-
-```python
-@deprecated(version='3.0.0', reason='Use Stash.IsPackageGroup instead')
-def is_packagegroup(stash: Stash, *args, **kwargs)
-```
-
-Legacy interface is_packagegroup
-
-Use Stash.IsPackageGroup instead
-
-**Arguments**:
-
-- `stash` _Stash_ - Stash object
-  
-
-**Returns**:
-
-- `Stash.IsPackageGroup` - .
-
-<a id="oelint_parser.constants"></a>
-
-# oelint\_parser.constants
-
-<a id="oelint_parser.constants.Constants"></a>
-
-## Constants Objects
-
-```python
-class Constants()
-```
-
-Interface for constants
-
-<a id="oelint_parser.constants.Constants.GetByPath"></a>
-
-#### GetByPath
-
-```python
-def GetByPath(path: str) -> Union[Dict, List]
-```
-
-Get constant from path
-
-**Arguments**:
-
-- `path` _str_ - / joined path in the constant structure
-  
-
-**Returns**:
-
-  Union[Dict, List]: Item in structure or empty dictionary
-
-<a id="oelint_parser.constants.Constants.AddConstants"></a>
-
-#### AddConstants
-
-```python
-def AddConstants(_dict: dict) -> None
-```
-
-Add constants to the existing
-
-**Arguments**:
-
-- `dict` _dict_ - constant dictionary to add
-
-<a id="oelint_parser.constants.Constants.RemoveConstants"></a>
-
-#### RemoveConstants
-
-```python
-def RemoveConstants(_dict: dict) -> None
-```
-
-Remove constants from the existing
-
-**Arguments**:
-
-- `dict` _dict_ - constant dictionary to remove
-
-<a id="oelint_parser.constants.Constants.OverrideConstants"></a>
-
-#### OverrideConstants
-
-```python
-def OverrideConstants(_dict: dict) -> None
-```
-
-Override constants in the existing db
-
-**Arguments**:
-
-- `dict` _dict]_ - constant dictionary with override values
-
-<a id="oelint_parser.constants.Constants.FunctionsKnown"></a>
-
-#### FunctionsKnown
-
-```python
-@property
-def FunctionsKnown() -> List[str]
-```
-
-Return known functions
-
-**Returns**:
-
-- `list` - list of known functions
-
-<a id="oelint_parser.constants.Constants.FunctionsOrder"></a>
-
-#### FunctionsOrder
-
-```python
-@property
-def FunctionsOrder() -> List[str]
-```
-
-Return function order
-
-**Returns**:
-
-- `list` - List of functions to order in their designated order
-
-<a id="oelint_parser.constants.Constants.VariablesMandatory"></a>
-
-#### VariablesMandatory
-
-```python
-@property
-def VariablesMandatory() -> List[str]
-```
-
-Return mandatory variables
-
-**Returns**:
-
-- `list` - List of mandatory variables
-
-<a id="oelint_parser.constants.Constants.VariablesSuggested"></a>
-
-#### VariablesSuggested
-
-```python
-@property
-def VariablesSuggested() -> List[str]
-```
-
-Return suggested variables
-
-**Returns**:
-
-- `list` - List of suggested variables
-
-<a id="oelint_parser.constants.Constants.MirrorsKnown"></a>
-
-#### MirrorsKnown
-
-```python
-@property
-def MirrorsKnown() -> Dict[str, str]
-```
-
-Return known mirrors and their replacements
-
-**Returns**:
-
-- `dict` - Dict of known mirrors and their replacements
-
-<a id="oelint_parser.constants.Constants.VariablesProtected"></a>
-
-#### VariablesProtected
-
-```python
-@property
-def VariablesProtected() -> List[str]
-```
-
-Return protected variables
-
-**Returns**:
-
-- `list` - List of protected variables
-
-<a id="oelint_parser.constants.Constants.VariablesProtectedAppend"></a>
-
-#### VariablesProtectedAppend
-
-```python
-@property
-def VariablesProtectedAppend() -> List[str]
-```
-
-Return protected variables in bbappend files
-
-**Returns**:
-
-- `list` - List of protected variables in bbappend files
-
-<a id="oelint_parser.constants.Constants.VariablesOrder"></a>
-
-#### VariablesOrder
-
-```python
-@property
-def VariablesOrder() -> List[str]
-```
-
-Variable order
-
-**Returns**:
-
-- `list` - List of variables to order in their designated order
-
-<a id="oelint_parser.constants.Constants.VariablesKnown"></a>
-
-#### VariablesKnown
-
-```python
-@property
-def VariablesKnown() -> List[str]
-```
-
-Known variables
-
-**Returns**:
-
-- `list` - List of known variables
-
-<a id="oelint_parser.constants.Constants.DistrosKnown"></a>
-
-#### DistrosKnown
-
-```python
-@property
-def DistrosKnown() -> List[str]
-```
-
-Known distros
-
-**Returns**:
-
-- `list` - List of known distros
-
-<a id="oelint_parser.constants.Constants.MachinesKnown"></a>
-
-#### MachinesKnown
-
-```python
-@property
-def MachinesKnown() -> List[str]
-```
-
-Known machines
-
-**Returns**:
-
-- `list` - List of known machines
-
-<a id="oelint_parser.constants.Constants.ImagesClasses"></a>
-
-#### ImagesClasses
-
-```python
-@property
-def ImagesClasses() -> List[str]
-```
-
-Classes that are used in images
-
-**Returns**:
-
-- `list` - Classes that are used in images
-
-<a id="oelint_parser.constants.Constants.ImagesVariables"></a>
-
-#### ImagesVariables
-
-```python
-@property
-def ImagesVariables() -> List[str]
-```
-
-Variables that are used in images
-
-**Returns**:
-
-- `list` - Variables that are used in images
-
-<a id="oelint_parser.constants.Constants.SetsBase"></a>
-
-#### SetsBase
-
-```python
-@property
-def SetsBase() -> Dict[str, str]
-```
-
-Base variable set
-
-**Returns**:
-
-- `dict` - dictionary with base variable set
+- `list` - List of oelint_parser.cls_item.* representations
 
 <a id="oelint_parser.cls_item"></a>
 
@@ -3748,108 +2931,941 @@ get items
 
 - `list` - variable name, variable flag
 
-<a id="oelint_parser.parser"></a>
+<a id="oelint_parser.helper_files"></a>
 
-# oelint\_parser.parser
+# oelint\_parser.helper\_files
 
-<a id="oelint_parser.parser.get_full_scope"></a>
+<a id="oelint_parser.helper_files.get_files"></a>
 
-#### get\_full\_scope
+#### get\_files
 
 ```python
-def get_full_scope(_string: str, offset: int, _sstart: int, _send: int) -> str
+@deprecated(version='3.0.0', reason='Use Stash.GetFiles instead')
+def get_files(stash: Stash, *args, **kwargs)
 ```
 
-get full block of an inline statement
+Legacy interface get_files.
+
+Use Stash.GetFiles instead.
 
 **Arguments**:
 
-- `_string` _str_ - input string
-- `offset` _int_ - offset in string
-- `_sstart` _int_ - block start index
-- `_send` _int_ - block end index
+- `stash` _Stash_ - Stash object
   
 
 **Returns**:
 
-- `str` - full block on inline statement
+- `Stash.GetFiles` - .
 
-<a id="oelint_parser.parser.prepare_lines_subparser"></a>
+<a id="oelint_parser.helper_files.get_layer_root"></a>
 
-#### prepare\_lines\_subparser
+#### get\_layer\_root
 
 ```python
-def prepare_lines_subparser(_iter: Iterable,
-                            lineOffset: int,
-                            num: int,
-                            line: int,
-                            raw_line: str = None,
-                            negative: bool = False) -> List[str]
+@deprecated(version='3.0.0', reason='Use Stash.GetLayerRoot instead')
+def get_layer_root(*args, **kwargs)
 ```
 
-preprocess raw input
+Legacy interface get_layer_root
+
+Use Stash.GetLayerRoot instead.
+
+**Returns**:
+
+- `Stash.GetLayerRoot` - .
+
+<a id="oelint_parser.helper_files.find_local_or_in_layer"></a>
+
+#### find\_local\_or\_in\_layer
+
+```python
+@deprecated(version='3.0.0', reason='Use Stash.FindLocalOrLayer instead')
+def find_local_or_in_layer(*args, **kwargs)
+```
+
+Legacy interface find_local_or_in_layer
+
+Use Stash.FindLocalOrLayer instead.
+
+**Returns**:
+
+- `Stash.FindLocalOrLayer` - .
+
+<a id="oelint_parser.helper_files.get_scr_components"></a>
+
+#### get\_scr\_components
+
+```python
+@deprecated(version='3.0.0', reason='Use Stash.GetScrComponents instead')
+def get_scr_components(*args, **kwargs)
+```
+
+Legacy interface get_scr_components
+
+Use Stash.GetScrComponents instead
+
+**Returns**:
+
+- `Stash.GetScrComponents` - .
+
+<a id="oelint_parser.helper_files.safe_linesplit"></a>
+
+#### safe\_linesplit
+
+```python
+@deprecated(version='3.0.0', reason='Use Stash.SafeLineSplit instead')
+def safe_linesplit(*args, **kwargs)
+```
+
+Legacy interface safe_linesplit
+
+Use Stash.SafeLineSplit instead
+
+**Returns**:
+
+- `Stash.SafeLineSplit` - .
+
+<a id="oelint_parser.helper_files.guess_recipe_name"></a>
+
+#### guess\_recipe\_name
+
+```python
+@deprecated(version='3.0.0', reason='Use Stash.GuessRecipeName instead')
+def guess_recipe_name(*args, **kwargs)
+```
+
+Legacy interface guess_recipe_name
+
+Use Stash.GuessRecipeName instead
+
+**Returns**:
+
+- `Stash.GuessBaseRecipeName` - .
+
+<a id="oelint_parser.helper_files.guess_base_recipe_name"></a>
+
+#### guess\_base\_recipe\_name
+
+```python
+@deprecated(version='3.0.0', reason='Use Stash.GuessBaseRecipeName instead')
+def guess_base_recipe_name(*args, **kwargs)
+```
+
+Legacy interface guess_base_recipe_name
+
+Use Stash.GuessBaseRecipeName instead
+
+**Returns**:
+
+- `Stash.GuessBaseRecipeName` - .
+
+<a id="oelint_parser.helper_files.guess_recipe_version"></a>
+
+#### guess\_recipe\_version
+
+```python
+@deprecated(version='3.0.0', reason='Use Stash.GuessRecipeVersion instead')
+def guess_recipe_version(*args, **kwargs)
+```
+
+Legacy interface guess_recipe_version
+
+Use Stash.GuessRecipeVersion instead
+
+**Returns**:
+
+- `Stash.GuessRecipeVersion` - .
+
+<a id="oelint_parser.helper_files.expand_term"></a>
+
+#### expand\_term
+
+```python
+@deprecated(version='3.0.0', reason='Use Stash.ExpandTerm instead')
+def expand_term(stash: Stash, *args, **kwargs)
+```
+
+Legacy interface expand_term
+
+Use Stash.ExpandTerm instead
 
 **Arguments**:
 
-- `_iter` _iterator_ - line interator object
-- `lineOffset` _int_ - current line index
-- `num` _int_ - internal line counter
-- `line` _int_ - input string
-- `raw_line` _string, optional_ - internal line representation. Defaults to None.
-- `negative` _bool_ - Negative branch inline expansion. Defaults to False
+- `stash` _Stash_ - Stash object
   
 
 **Returns**:
 
-- `list` - list of preproccessed chunks
+- `Stash.ExpandTerm` - .
 
-<a id="oelint_parser.parser.prepare_lines"></a>
+<a id="oelint_parser.helper_files.get_valid_package_names"></a>
 
-#### prepare\_lines
+#### get\_valid\_package\_names
 
 ```python
-def prepare_lines(_file: str,
-                  lineOffset: int = 0,
-                  negative: bool = False) -> List[str]
+@deprecated(version='3.0.0', reason='Use Stash.GetValidPackageNames instead')
+def get_valid_package_names(stash: Stash, *args, **kwargs)
 ```
 
-break raw file input into preprocessed chunks
+Legacy interface get_valid_package_names
+
+Use Stash.GetValidPackageNames instead
 
 **Arguments**:
 
-- `_file` _string_ - Full path to file
-- `lineOffset` _int, optional_ - line offset counter. Defaults to 0.
-- `negative` _bool_ - Negative branch inline expansion. Defaults to False
+- `stash` _Stash_ - Stash object
   
 
 **Returns**:
 
-- `list` - preprocessed list of chunks
+- `Stash.GetValidPackageNames` - .
 
-<a id="oelint_parser.parser.get_items"></a>
+<a id="oelint_parser.helper_files.get_valid_named_resources"></a>
 
-#### get\_items
+#### get\_valid\_named\_resources
 
 ```python
-def get_items(stash: object,
-              _file: str,
-              lineOffset: int = 0,
-              new_style_override_syntax: bool = False,
-              negative: bool = False) -> List[Item]
+@deprecated(version='3.0.0', reason='Use Stash.GetValidNamedResources instead')
+def get_valid_named_resources(stash: Stash, *args, **kwargs)
 ```
 
-parses file
+Legacy interface get_valid_named_resources
+
+Use Stash.GetValidNamedResources instead
 
 **Arguments**:
 
-- `stash` _oelint_parser.cls_stash.Stash_ - Stash object
-- `_file` _string_ - Full path to file
-- `lineOffset` _int, optional_ - line offset counter. Defaults to 0.
-- `new_style_override_syntax` _bool, optional_ - default to new override syntax (default: False)
-- `negative` _bool, optional_ - Negative branch inline expansion (default: False)
+- `stash` _Stash_ - Stash object
   
 
 **Returns**:
 
-- `list` - List of oelint_parser.cls_item.* representations
+- `Stash.GetValidNamedResources` - .
+
+<a id="oelint_parser.helper_files.is_image"></a>
+
+#### is\_image
+
+```python
+@deprecated(version='3.0.0', reason='Use Stash.IsImage instead')
+def is_image(stash: Stash, *args, **kwargs)
+```
+
+Legacy interface is_image
+
+Use Stash.IsImage instead
+
+**Arguments**:
+
+- `stash` _Stash_ - Stash object
+  
+
+**Returns**:
+
+- `Stash.IsImage` - .
+
+<a id="oelint_parser.helper_files.is_packagegroup"></a>
+
+#### is\_packagegroup
+
+```python
+@deprecated(version='3.0.0', reason='Use Stash.IsPackageGroup instead')
+def is_packagegroup(stash: Stash, *args, **kwargs)
+```
+
+Legacy interface is_packagegroup
+
+Use Stash.IsPackageGroup instead
+
+**Arguments**:
+
+- `stash` _Stash_ - Stash object
+  
+
+**Returns**:
+
+- `Stash.IsPackageGroup` - .
+
+<a id="oelint_parser.rpl_regex"></a>
+
+# oelint\_parser.rpl\_regex
+
+<a id="oelint_parser.rpl_regex.RegexRpl"></a>
+
+## RegexRpl Objects
+
+```python
+class RegexRpl()
+```
+
+Safe regex replacements
+
+<a id="oelint_parser.rpl_regex.RegexRpl.search"></a>
+
+#### search
+
+```python
+@staticmethod
+def search(pattern: str,
+           string: str,
+           timeout: int = 5,
+           default: object = None,
+           **kwargs) -> Union[Match, None]
+```
+
+replacement for re.search
+
+**Arguments**:
+
+- `pattern` _str_ - regex pattern
+- `string` _str_ - input string
+- `timeout` _int, optional_ - Timeout for operation. On timeout `default` will be returned. Defaults to 5.
+- `default` __type_, optional_ - Default to return on timeout. Defaults to None.
+  
+
+**Returns**:
+
+- `Match` - Match object or None
+
+<a id="oelint_parser.rpl_regex.RegexRpl.split"></a>
+
+#### split
+
+```python
+@staticmethod
+def split(pattern: str,
+          string: str,
+          timeout: int = 5,
+          default: object = None,
+          **kwargs) -> List[str]
+```
+
+replacement for re.split
+
+**Arguments**:
+
+- `pattern` _str_ - regex pattern
+- `string` _str_ - input string
+- `timeout` _int, optional_ - Timeout for operation. On timeout `default` will be returned. Defaults to 5.
+- `default` __type_, optional_ - Default to return on timeout. Defaults to None.
+  
+
+**Returns**:
+
+- `list` - list object or None
+
+<a id="oelint_parser.rpl_regex.RegexRpl.match"></a>
+
+#### match
+
+```python
+@staticmethod
+def match(pattern: str,
+          string: str,
+          timeout: int = 5,
+          default: object = None,
+          **kwargs) -> Union[Match, None]
+```
+
+replacement for re.match
+
+**Arguments**:
+
+- `pattern` _str_ - regex pattern
+- `string` _str_ - input string
+- `timeout` _int, optional_ - Timeout for operation. On timeout `default` will be returned. Defaults to 5.
+- `default` __type_, optional_ - Default to return on timeout. Defaults to None.
+  
+
+**Returns**:
+
+- `Match` - Match object or None
+
+<a id="oelint_parser.rpl_regex.RegexRpl.sub"></a>
+
+#### sub
+
+```python
+@staticmethod
+def sub(pattern: str,
+        repl: str,
+        string: str,
+        timeout: int = 5,
+        default: str = '',
+        **kwargs) -> str
+```
+
+replacement for re.sub
+
+**Arguments**:
+
+- `pattern` _str_ - regex pattern
+- `repl` _str_ - replacement string
+- `string` _str_ - input string
+- `timeout` _int, optional_ - Timeout for operation. On timeout `default` will be returned. Defaults to 5.
+- `default` __type_, optional_ - Default to return on timeout. Defaults to ''.
+  
+
+**Returns**:
+
+- `str` - string
+
+<a id="oelint_parser.rpl_regex.RegexRpl.finditer"></a>
+
+#### finditer
+
+```python
+@staticmethod
+def finditer(pattern: str,
+             string: str,
+             timeout: int = 5,
+             default: object = None,
+             **kwargs) -> Scanner
+```
+
+replacement for re.finditer
+
+**Arguments**:
+
+- `pattern` _str_ - regex pattern
+- `string` _str_ - input string
+- `timeout` _int, optional_ - Timeout for operation. On timeout `default` will be returned. Defaults to 5.
+- `default` __type_, optional_ - Default to return on timeout. Defaults to None.
+  
+
+**Returns**:
+
+- `Scanner` - Scanner object or None
+
+<a id="oelint_parser.constants"></a>
+
+# oelint\_parser.constants
+
+<a id="oelint_parser.constants.Constants"></a>
+
+## Constants Objects
+
+```python
+class Constants()
+```
+
+Interface for constants
+
+<a id="oelint_parser.constants.Constants.GetByPath"></a>
+
+#### GetByPath
+
+```python
+def GetByPath(path: str) -> Union[Dict, List]
+```
+
+Get constant from path
+
+**Arguments**:
+
+- `path` _str_ - / joined path in the constant structure
+  
+
+**Returns**:
+
+  Union[Dict, List]: Item in structure or empty dictionary
+
+<a id="oelint_parser.constants.Constants.AddConstants"></a>
+
+#### AddConstants
+
+```python
+def AddConstants(_dict: dict) -> None
+```
+
+Add constants to the existing
+
+**Arguments**:
+
+- `dict` _dict_ - constant dictionary to add
+
+<a id="oelint_parser.constants.Constants.RemoveConstants"></a>
+
+#### RemoveConstants
+
+```python
+def RemoveConstants(_dict: dict) -> None
+```
+
+Remove constants from the existing
+
+**Arguments**:
+
+- `dict` _dict_ - constant dictionary to remove
+
+<a id="oelint_parser.constants.Constants.OverrideConstants"></a>
+
+#### OverrideConstants
+
+```python
+def OverrideConstants(_dict: dict) -> None
+```
+
+Override constants in the existing db
+
+**Arguments**:
+
+- `dict` _dict]_ - constant dictionary with override values
+
+<a id="oelint_parser.constants.Constants.FunctionsKnown"></a>
+
+#### FunctionsKnown
+
+```python
+@property
+def FunctionsKnown() -> List[str]
+```
+
+Return known functions
+
+**Returns**:
+
+- `list` - list of known functions
+
+<a id="oelint_parser.constants.Constants.FunctionsOrder"></a>
+
+#### FunctionsOrder
+
+```python
+@property
+def FunctionsOrder() -> List[str]
+```
+
+Return function order
+
+**Returns**:
+
+- `list` - List of functions to order in their designated order
+
+<a id="oelint_parser.constants.Constants.VariablesMandatory"></a>
+
+#### VariablesMandatory
+
+```python
+@property
+def VariablesMandatory() -> List[str]
+```
+
+Return mandatory variables
+
+**Returns**:
+
+- `list` - List of mandatory variables
+
+<a id="oelint_parser.constants.Constants.VariablesSuggested"></a>
+
+#### VariablesSuggested
+
+```python
+@property
+def VariablesSuggested() -> List[str]
+```
+
+Return suggested variables
+
+**Returns**:
+
+- `list` - List of suggested variables
+
+<a id="oelint_parser.constants.Constants.MirrorsKnown"></a>
+
+#### MirrorsKnown
+
+```python
+@property
+def MirrorsKnown() -> Dict[str, str]
+```
+
+Return known mirrors and their replacements
+
+**Returns**:
+
+- `dict` - Dict of known mirrors and their replacements
+
+<a id="oelint_parser.constants.Constants.VariablesProtected"></a>
+
+#### VariablesProtected
+
+```python
+@property
+def VariablesProtected() -> List[str]
+```
+
+Return protected variables
+
+**Returns**:
+
+- `list` - List of protected variables
+
+<a id="oelint_parser.constants.Constants.VariablesProtectedAppend"></a>
+
+#### VariablesProtectedAppend
+
+```python
+@property
+def VariablesProtectedAppend() -> List[str]
+```
+
+Return protected variables in bbappend files
+
+**Returns**:
+
+- `list` - List of protected variables in bbappend files
+
+<a id="oelint_parser.constants.Constants.VariablesOrder"></a>
+
+#### VariablesOrder
+
+```python
+@property
+def VariablesOrder() -> List[str]
+```
+
+Variable order
+
+**Returns**:
+
+- `list` - List of variables to order in their designated order
+
+<a id="oelint_parser.constants.Constants.VariablesKnown"></a>
+
+#### VariablesKnown
+
+```python
+@property
+def VariablesKnown() -> List[str]
+```
+
+Known variables
+
+**Returns**:
+
+- `list` - List of known variables
+
+<a id="oelint_parser.constants.Constants.DistrosKnown"></a>
+
+#### DistrosKnown
+
+```python
+@property
+def DistrosKnown() -> List[str]
+```
+
+Known distros
+
+**Returns**:
+
+- `list` - List of known distros
+
+<a id="oelint_parser.constants.Constants.MachinesKnown"></a>
+
+#### MachinesKnown
+
+```python
+@property
+def MachinesKnown() -> List[str]
+```
+
+Known machines
+
+**Returns**:
+
+- `list` - List of known machines
+
+<a id="oelint_parser.constants.Constants.ImagesClasses"></a>
+
+#### ImagesClasses
+
+```python
+@property
+def ImagesClasses() -> List[str]
+```
+
+Classes that are used in images
+
+**Returns**:
+
+- `list` - Classes that are used in images
+
+<a id="oelint_parser.constants.Constants.ImagesVariables"></a>
+
+#### ImagesVariables
+
+```python
+@property
+def ImagesVariables() -> List[str]
+```
+
+Variables that are used in images
+
+**Returns**:
+
+- `list` - Variables that are used in images
+
+<a id="oelint_parser.constants.Constants.SetsBase"></a>
+
+#### SetsBase
+
+```python
+@property
+def SetsBase() -> Dict[str, str]
+```
+
+Base variable set
+
+**Returns**:
+
+- `dict` - dictionary with base variable set
+
+<a id="oelint_parser.inlinerep"></a>
+
+# oelint\_parser.inlinerep
+
+<a id="oelint_parser.inlinerep.bb_utils_filter"></a>
+
+#### bb\_utils\_filter
+
+```python
+def bb_utils_filter(_in: str, negative_clause: bool = False) -> str
+```
+
+bb.utils.filter emulation
+
+**Arguments**:
+
+- `_in` _str_ - Input string
+- `negative_clause` _bool_ - return negative branch
+  
+
+**Returns**:
+
+- `str` - True argument of the conditional or None if not applicable
+
+<a id="oelint_parser.inlinerep.bb_utils_contains"></a>
+
+#### bb\_utils\_contains
+
+```python
+def bb_utils_contains(_in: str, negative_clause: bool = False) -> str
+```
+
+bb.utils.contains emulation
+
+**Arguments**:
+
+- `_in` _str_ - Input string
+- `negative_clause` _bool_ - return negative branch
+  
+
+**Returns**:
+
+- `str` - True argument of the conditional or None if not applicable
+
+<a id="oelint_parser.inlinerep.bb_utils_contains_any"></a>
+
+#### bb\_utils\_contains\_any
+
+```python
+def bb_utils_contains_any(_in: str, negative_clause: bool = False) -> str
+```
+
+bb.utils.contains_any emulation
+
+**Arguments**:
+
+- `_in` _str_ - Input string
+- `negative_clause` _bool_ - return negative branch
+  
+
+**Returns**:
+
+- `str` - True argument of the conditional or None if not applicable
+
+<a id="oelint_parser.inlinerep.oe_utils_conditional"></a>
+
+#### oe\_utils\_conditional
+
+```python
+def oe_utils_conditional(_in: str, negative_clause: bool = False) -> str
+```
+
+oe.utils.conditional emulation
+
+**Arguments**:
+
+- `_in` _str_ - Input string
+- `negative_clause` _bool_ - return negative branch
+  
+
+**Returns**:
+
+- `str` - True argument of the conditional or None if not applicable
+
+<a id="oelint_parser.inlinerep.oe_utils_ifelse"></a>
+
+#### oe\_utils\_ifelse
+
+```python
+def oe_utils_ifelse(_in: str, negative_clause: bool = False) -> str
+```
+
+oe.utils.ifelse emulation
+
+**Arguments**:
+
+- `_in` _str_ - Input string
+- `negative_clause` _bool_ - return negative branch
+  
+
+**Returns**:
+
+- `str` - True argument of the conditional or None if not applicable
+
+<a id="oelint_parser.inlinerep.oe_utils_any_distro_features"></a>
+
+#### oe\_utils\_any\_distro\_features
+
+```python
+def oe_utils_any_distro_features(_in: str,
+                                 negative_clause: bool = False) -> str
+```
+
+oe.utils.any_distro_features emulation
+
+**Arguments**:
+
+- `_in` _str_ - Input string
+- `negative_clause` _bool_ - return negative branch
+  
+
+**Returns**:
+
+- `str` - True argument of the conditional or None if not applicable
+
+<a id="oelint_parser.inlinerep.oe_utils_all_distro_features"></a>
+
+#### oe\_utils\_all\_distro\_features
+
+```python
+def oe_utils_all_distro_features(_in: str,
+                                 negative_clause: bool = False) -> str
+```
+
+oe.utils.all_distro_features emulation
+
+**Arguments**:
+
+- `_in` _str_ - Input string
+- `negative_clause` _bool_ - return negative branch
+  
+
+**Returns**:
+
+- `str` - True argument of the conditional or None if not applicable
+
+<a id="oelint_parser.inlinerep.oe_utils_vartrue"></a>
+
+#### oe\_utils\_vartrue
+
+```python
+def oe_utils_vartrue(_in: str, negative_clause: bool = False) -> str
+```
+
+oe.utils.vartrue emulation
+
+**Arguments**:
+
+- `_in` _str_ - Input string
+- `negative_clause` _bool_ - return negative branch
+  
+
+**Returns**:
+
+- `str` - True argument of the conditional or None if not applicable
+
+<a id="oelint_parser.inlinerep.oe_utils_less_or_equal"></a>
+
+#### oe\_utils\_less\_or\_equal
+
+```python
+def oe_utils_less_or_equal(_in: str, negative_clause: bool = False) -> str
+```
+
+oe.utils.less_or_equal emulation
+
+**Arguments**:
+
+- `_in` _str_ - Input string
+- `negative_clause` _bool_ - return negative branch
+  
+
+**Returns**:
+
+- `str` - True argument of the conditional or None if not applicable
+
+<a id="oelint_parser.inlinerep.oe_utils_version_less_or_equal"></a>
+
+#### oe\_utils\_version\_less\_or\_equal
+
+```python
+def oe_utils_version_less_or_equal(_in: str,
+                                   negative_clause: bool = False) -> str
+```
+
+oe.utils.version_less_or_equal emulation
+
+**Arguments**:
+
+- `_in` _str_ - Input string
+- `negative_clause` _bool_ - return negative branch
+  
+
+**Returns**:
+
+- `str` - True argument of the conditional or None if not applicable
+
+<a id="oelint_parser.inlinerep.oe_utils_both_contain"></a>
+
+#### oe\_utils\_both\_contain
+
+```python
+def oe_utils_both_contain(_in: str, negative_clause: bool = False) -> str
+```
+
+oe.utils.both_contain emulation
+
+**Arguments**:
+
+- `_in` _str_ - Input string
+- `negative_clause` _bool_ - return negative branch
+  
+
+**Returns**:
+
+- `str` - True argument of the conditional or None if not applicable
+
+<a id="oelint_parser.inlinerep.inlinerep"></a>
+
+#### inlinerep
+
+```python
+def inlinerep(_in: str, negative_clause: bool = False) -> str
+```
+
+Replaces inline code expressions
+
+**Arguments**:
+
+- `_in` _str_ - Input string
+- `negative_clause` _bool_ - return negative branch
+  
+
+**Returns**:
+
+- `str` - Expanded string or None, if not applicable
 

--- a/oelint_parser/cls_stash.py
+++ b/oelint_parser/cls_stash.py
@@ -1,4 +1,5 @@
 import functools
+import hashlib
 import glob
 import os
 from collections import UserList
@@ -120,6 +121,7 @@ class Stash():
         self.__quiet = quiet
         self.__new_style_override_syntax = new_style_override_syntax
         self.__negative_inline = negative_inline
+        self.__fingerprint = hashlib.sha1(f'{self.__new_style_override_syntax}:{self.__negative_inline}'.encode())  # noqa: DUO130, S324
 
         self._clear_cached()
 
@@ -190,7 +192,20 @@ class Stash():
         # Reset caches
         self._clear_cached()
 
+        # update fingerprint
+        for item in res:
+            self.__fingerprint.update(str(item).encode())
+
         return res
+
+    @property
+    def FingerPrint(self) -> str:
+        """Get the SHA1 fingerprint of the current Stash
+
+        Returns:
+            str: hexdigest checksum
+        """
+        return self.__fingerprint.hexdigest()
 
     def Append(self, item: Union[Item, Iterable[Item]]) -> None:
         """appends one or mote items to the stash


### PR DESCRIPTION
which gives a checksum of the current Stash object including the parser relevant options and all of the extracted objects.
This can help to decide if there has been changes to a known baseline.
Those baselines can only be safely calculated on the very same host from the same setup, as the Stash objects contain absolute paths.