### PR TITLE
requirements-dev: drop flake8-logging-format

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,6 @@ flake8-executable == 2.1.3
 flake8-fixme == 1.1.1
 flake8-functions == 0.0.8
 flake8-isort == 6.1.1
-flake8-logging-format == 0.9.0
 flake8-mutable == 1.2.0
 flake8-pep3101 == 2.1.0
 flake8-print == 5.0.0


### PR DESCRIPTION
as upstream is creating releases without tags in
a non-transparent way, so that resource can't be trusted anymore