### PR TITLE
parser: allow / in variable flags

### DIFF
--- a/oelint_parser/parser.py
+++ b/oelint_parser/parser.py
@@ -40,7 +40,7 @@ __regex_addtask = regex.compile(
     r"^(\s*|\t*)addtask\s+(?P<func>[\w\-]+)\s*((before\s*(?P<before>(([^#\n]*(?=after))|([^#\n]*))))|(after\s*(?P<after>(([^#\n]*(?=before))|([^#\n]*)))))*(?P<comment>#.*|.*?)")
 __regex_deltask = regex.compile(r"^(\s*|\t*)deltask\s+(?P<func>[\w\-]+)\s*(?P<comment>#.*)*")
 __regex_flagass = regex.compile(
-    r"^(\s*|\t*)(?P<name>([A-Z0-9a-z_.-]|\$|\{|\}|:)+?)\[(?P<ident>(\w|-|\.)+)\](?P<varop>(\s|\t)*(\+|\?|\:|\.)*=(\+|\.)*(\s|\t)*)(?P<varval>.*)")
+    r"^(\s*|\t*)(?P<name>([A-Z0-9a-z_.-]|\$|\{|\}|:)+?)\[(?P<ident>(\w|-|\.|/|@|_)+)\](?P<varop>(\s|\t)*(\+|\?|\:|\.)*=(\+|\.)*(\s|\t)*)(?P<varval>.*)")
 __regex_export_func = regex.compile(r"^EXPORT_FUNCTIONS\s+(?P<func>.*)")
 __regex_addpylib = regex.compile(r"^(\s+|\t*)addpylib(\s+|\t+)(?P<path>\$\{LAYERDIR\}/.+)(\s+|\t+)(?P<namespace>.*)")
 __regex_unset = regex.compile(r"^(\s+|\t+)*unset(\s+|\t+)+(?P<varname>.+?)(\[*(?P<flag>.+)\])*")

--- a/tests/test-recipe-new_1.0.bb
+++ b/tests/test-recipe-new_1.0.bb
@@ -16,3 +16,7 @@ Y = "${P}"
 SRCREV_foo = "abcd"
 
 C  += "1"
+
+VAR_FLAG_WITH_SLASH[abc/def] = "abcd"
+VAR_FLAG_WITH_AT[abc@def] = "abcd"
+VAR_FLAG_WITH_UNDERLINE[abc_def] = "abcd"

--- a/tests/test_parser_new.py
+++ b/tests/test_parser_new.py
@@ -206,6 +206,48 @@ class OelintParserTestNew(unittest.TestCase):
             self.assertEqual(x.IsAppend(), True)
             self.assertIn('  += ', x.AppendOperation())
 
+    def test_var_flag_slash(self):
+        from oelint_parser.cls_item import FlagAssignment
+        from oelint_parser.cls_stash import Stash
+
+        self.__stash = Stash()
+        self.__stash.AddFile(OelintParserTestNew.RECIPE)
+
+        _stash = self.__stash.GetItemsFor(classifier=FlagAssignment.CLASSIFIER,
+                                          attribute=FlagAssignment.ATTR_NAME,
+                                          attributeValue="VAR_FLAG_WITH_SLASH")
+        self.assertTrue(_stash, msg="Stash has items")
+        for x in _stash:
+            self.assertEqual(x.Flag, 'abc/def')
+
+    def test_var_flag_at(self):
+        from oelint_parser.cls_item import FlagAssignment
+        from oelint_parser.cls_stash import Stash
+
+        self.__stash = Stash()
+        self.__stash.AddFile(OelintParserTestNew.RECIPE)
+
+        _stash = self.__stash.GetItemsFor(classifier=FlagAssignment.CLASSIFIER,
+                                          attribute=FlagAssignment.ATTR_NAME,
+                                          attributeValue="VAR_FLAG_WITH_AT")
+        self.assertTrue(_stash, msg="Stash has items")
+        for x in _stash:
+            self.assertEqual(x.Flag, 'abc@def')
+
+    def test_var_flag_underline(self):
+        from oelint_parser.cls_item import FlagAssignment
+        from oelint_parser.cls_stash import Stash
+
+        self.__stash = Stash()
+        self.__stash.AddFile(OelintParserTestNew.RECIPE)
+
+        _stash = self.__stash.GetItemsFor(classifier=FlagAssignment.CLASSIFIER,
+                                          attribute=FlagAssignment.ATTR_NAME,
+                                          attributeValue="VAR_FLAG_WITH_UNDERLINE")
+        self.assertTrue(_stash, msg="Stash has items")
+        for x in _stash:
+            self.assertEqual(x.Flag, 'abc_def')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
also add support for @ and underline character,
that missing in before

Closes #276