### PR TITLE
parser: add support to expand inline-blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ for x in _stash.GetItemsFor(attribute=Variable.ATTR_VAR, attributeValue="PV"):
     # single items from a list
     print(x.get_items())
     # expanded single items from a list
-    print([_stash.ExpandTerm("/some/file", y) for y in x.get_items()])
+    print([_stash.ExpandTerm("/some/file", y, objref=x) for y in x.get_items()])
 ```
 
 ### Filtering

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -764,7 +764,8 @@ Get recipe version from filename
 def ExpandTerm(_file: str,
                value: str,
                spare: List[str] = None,
-               seen: List[str] = None) -> str
+               seen: List[str] = None,
+               objref: Variable = None) -> str
 ```
 
 Expand a variable (replacing all variables by known content)
@@ -775,6 +776,7 @@ Expand a variable (replacing all variables by known content)
 - `value` _str_ - Variable value to expand
 - `spare` _list[str]_ - items to keep unexpanded (default: None)
 - `seen` _list[str]_ - seen items (default: None)
+- `objref` _Variable_ - reference to the calling variable instance (default: None)
   
 
 **Returns**:
@@ -997,6 +999,7 @@ def __init__(origin: str,
              infileline: int,
              rawtext: str,
              realraw: str,
+             inline_blocks: List[Tuple[str, str]],
              new_style_override_syntax: bool = False) -> None
 ```
 
@@ -1249,34 +1252,16 @@ Items representing variables in bitbake.
 #### \_\_init\_\_
 
 ```python
-def __init__(origin: str,
-             line: int,
-             infileline: int,
-             rawtext: str,
-             name: str,
-             value: str,
-             operator: str,
-             realraw: str,
-             new_style_override_syntax: bool = False) -> None
+def __init__(name: str, value: str, operator: str, *args, **kwargs) -> None
 ```
 
 constructor
 
 **Arguments**:
 
-- `origin` _str_ - Full path to file of origin
-- `line` _int_ - Overall line counter
-- `infileline` _int_ - Line counter in the particular file
-- `rawtext` _str_ - Raw input string (except inline code blocks)
-- `realraw` _str_ - Unprocessed input
 - `name` _str_ - Variable name
 - `value` _str_ - Variable value
 - `operator` _str_ - Operation performed to the variable
-  
-
-**Arguments**:
-
-- `new_style_override_syntax` _bool_ - Use ':' a override delimiter (default: {False})
 
 <a id="oelint_parser.cls_item.Variable.VarName"></a>
 
@@ -1546,28 +1531,10 @@ Items representing comments in bitbake.
 #### \_\_init\_\_
 
 ```python
-def __init__(origin: str,
-             line: int,
-             infileline: int,
-             rawtext: str,
-             realraw: str,
-             new_style_override_syntax: bool = False) -> None
+def __init__(*args, **kwargs) -> None
 ```
 
 constructor
-
-**Arguments**:
-
-- `origin` _str_ - Full path to file of origin
-- `line` _int_ - Overall line counter
-- `infileline` _int_ - Line counter in the particular file
-- `rawtext` _str_ - Raw input string (except inline code blocks)
-- `realraw` _str_ - Unprocessed input
-  
-
-**Arguments**:
-
-- `new_style_override_syntax` _bool_ - Use ':' a override delimiter (default: {False})
 
 <a id="oelint_parser.cls_item.Comment.get_items"></a>
 
@@ -1598,34 +1565,17 @@ Items that representing include/require statements.
 #### \_\_init\_\_
 
 ```python
-def __init__(origin: str,
-             line: int,
-             infileline: int,
-             rawtext: str,
-             incname: str,
-             fileincluded: str,
-             statement: str,
-             realraw: str,
-             new_style_override_syntax: bool = False) -> None
+def __init__(incname: str, fileincluded: str, statement: str, *args,
+             **kwargs) -> None
 ```
 
 constructor
 
 **Arguments**:
 
-- `origin` _str_ - Full path to file of origin
-- `line` _int_ - Overall line counter
-- `infileline` _int_ - Line counter in the particular file
-- `rawtext` _str_ - Raw input string (except inline code blocks)
-- `realraw` _str_ - Unprocessed input
 - `incname` _str_ - raw name of the include file
 - `fileincluded` _str_ - path of the file included
 - `statement` _str_ - either include or require
-  
-
-**Arguments**:
-
-- `new_style_override_syntax` _bool_ - Use ':' a override delimiter (default: {False})
 
 <a id="oelint_parser.cls_item.Include.IncName"></a>
 
@@ -1701,25 +1651,13 @@ Items representing export statements in bitbake.
 #### \_\_init\_\_
 
 ```python
-def __init__(origin: str,
-             line: int,
-             infileline: int,
-             rawtext: str,
-             name: str,
-             value: str,
-             realraw: str,
-             new_style_override_syntax: bool = False) -> None
+def __init__(name: str, value: str, *args, **kwargs) -> None
 ```
 
 constructor
 
 **Arguments**:
 
-- `origin` _str_ - Full path to file of origin
-- `line` _int_ - Overall line counter
-- `infileline` _int_ - Line counter in the particular file
-- `rawtext` _str_ - Raw input string (except inline code blocks)
-- `realraw` _str_ - Unprocessed input
 - `name` _str_ - variable name of the export
 - `value` _str_ - (optional) value of the export
   
@@ -1787,27 +1725,18 @@ Items representing task definitions in bitbake.
 #### \_\_init\_\_
 
 ```python
-def __init__(origin: str,
-             line: int,
-             infileline: int,
-             rawtext: str,
-             name: str,
+def __init__(name: str,
              body: str,
-             realraw: str,
              python: bool = False,
              fakeroot: bool = False,
-             new_style_override_syntax: bool = False) -> None
+             *args,
+             **kwargs) -> None
 ```
 
 [summary]
 
 **Arguments**:
 
-- `origin` _str_ - Full path to file of origin
-- `line` _int_ - Overall line counter
-- `infileline` _int_ - Line counter in the particular file
-- `rawtext` _str_ - Raw input string (except inline code blocks)
-- `realraw` _str_ - Unprocessed input
 - `name` _str_ - Raw function name
 - `body` _str_ - Function body
   
@@ -1816,7 +1745,6 @@ def __init__(origin: str,
 
 - `python` _bool_ - python function according to parser (default: {False})
 - `fakeroot` _bool_ - uses fakeroot (default: {False})
-- `new_style_override_syntax` _bool_ - Use ':' a override delimiter (default: {False})
 
 <a id="oelint_parser.cls_item.Function.IsPython"></a>
 
@@ -2024,30 +1952,14 @@ Items representing python functions in bitbake.
 #### \_\_init\_\_
 
 ```python
-def __init__(origin: str,
-             line: int,
-             infileline: int,
-             rawtext: str,
-             name: str,
-             realraw: str,
-             new_style_override_syntax: bool = False) -> None
+def __init__(name: str, *args, **kwargs) -> None
 ```
 
 constructor
 
 **Arguments**:
 
-- `origin` _str_ - Full path to file of origin
-- `line` _int_ - Overall line counter
-- `infileline` _int_ - Line counter in the particular file
-- `rawtext` _str_ - Raw input string (except inline code blocks)
-- `realraw` _str_ - Unprocessed input
 - `name` _str_ - Function name
-  
-
-**Arguments**:
-
-- `new_style_override_syntax` _bool_ - Use ':' a override delimiter (default: {False})
 
 <a id="oelint_parser.cls_item.PythonBlock.FuncName"></a>
 
@@ -2093,36 +2005,18 @@ Items representing flag assignments in bitbake.
 #### \_\_init\_\_
 
 ```python
-def __init__(origin: str,
-             line: int,
-             infileline: int,
-             rawtext: str,
-             name: str,
-             ident: str,
-             value: str,
-             varop: str,
-             realraw: str,
-             new_style_override_syntax: bool = False) -> None
+def __init__(name: str, ident: str, value: str, varop: str, *args,
+             **kwargs) -> None
 ```
 
 constructor
 
 **Arguments**:
 
-- `origin` _str_ - Full path to file of origin
-- `line` _int_ - Overall line counter
-- `infileline` _int_ - Line counter in the particular file
-- `rawtext` _str_ - Raw input string (except inline code blocks)
-- `realraw` _str_ - Unprocessed input
 - `name` _str_ - name of task to be modified
 - `ident` _str_ - task flag
 - `value` _str_ - value of modification
 - `varop` _str_ - variable operation
-  
-
-**Arguments**:
-
-- `new_style_override_syntax` _bool_ - Use ':' a override delimiter (default: {False})
 
 <a id="oelint_parser.cls_item.FlagAssignment.VarName"></a>
 
@@ -2228,30 +2122,14 @@ Items representing EXPORT_FUNCTIONS in bitbake.
 #### \_\_init\_\_
 
 ```python
-def __init__(origin: str,
-             line: int,
-             infileline: int,
-             rawtext: str,
-             name: str,
-             realraw: str,
-             new_style_override_syntax: bool = False) -> None
+def __init__(name: str, *args, **kwargs) -> None
 ```
 
 constructor
 
 **Arguments**:
 
-- `origin` _str_ - Full path to file of origin
-- `line` _int_ - Overall line counter
-- `infileline` _int_ - Line counter in the particular file
-- `rawtext` _str_ - Raw input string (except inline code blocks)
-- `realraw` _str_ - Unprocessed input
 - `name` _str_ - name of function to be exported
-  
-
-**Arguments**:
-
-- `new_style_override_syntax` _bool_ - Use ':' a override delimiter (default: {False})
 
 <a id="oelint_parser.cls_item.FunctionExports.FuncNames"></a>
 
@@ -2311,27 +2189,18 @@ Items representing addtask statements in bitbake.
 #### \_\_init\_\_
 
 ```python
-def __init__(origin: str,
-             line: int,
-             infileline: int,
-             rawtext: str,
-             name: str,
-             realraw: str,
+def __init__(name: str,
              before: str = "",
              after: str = "",
              comment: str = "",
-             new_style_override_syntax: bool = False) -> None
+             *args,
+             **kwargs) -> None
 ```
 
 constructor
 
 **Arguments**:
 
-- `origin` _str_ - Full path to file of origin
-- `line` _int_ - Overall line counter
-- `infileline` _int_ - Line counter in the particular file
-- `rawtext` _str_ - Raw input string (except inline code blocks)
-- `realraw` _str_ - Unprocessed input
 - `name` _str_ - name of task to be executed
   
 
@@ -2340,7 +2209,6 @@ constructor
 - `before` _str_ - before statement (default: {""})
 - `after` _str_ - after statement (default: {""})
 - `comment` _str_ - optional comment (default: {""})
-- `new_style_override_syntax` _bool_ - Use ':' a override delimiter (default: {False})
 
 <a id="oelint_parser.cls_item.TaskAdd.FuncName"></a>
 
@@ -2431,32 +2299,15 @@ Items representing deltask statements in bitbake.
 #### \_\_init\_\_
 
 ```python
-def __init__(origin: str,
-             line: int,
-             infileline: int,
-             rawtext: str,
-             name: str,
-             comment: str,
-             realraw: str,
-             new_style_override_syntax: bool = False) -> None
+def __init__(name: str, comment: str, *args, **kwargs) -> None
 ```
 
 constructor
 
 **Arguments**:
 
-- `origin` _str_ - Full path to file of origin
-- `line` _int_ - Overall line counter
-- `infileline` _int_ - Line counter in the particular file
-- `rawtext` _str_ - Raw input string (except inline code blocks)
-- `realraw` _str_ - Unprocessed input
 - `name` _str_ - name of task to be executed
 - `comment` _str_ - optional comment
-  
-
-**Arguments**:
-
-- `new_style_override_syntax` _bool_ - Use ':' a override delimiter (default: {False})
 
 <a id="oelint_parser.cls_item.TaskDel.FuncName"></a>
 
@@ -2517,28 +2368,15 @@ Items representing missing files found while parsing.
 #### \_\_init\_\_
 
 ```python
-def __init__(origin: str,
-             line: int,
-             infileline: int,
-             filename: str,
-             statement: str,
-             new_style_override_syntax: bool = False) -> None
+def __init__(filename: str, statement: str, *args, **kwargs) -> None
 ```
 
 constructor
 
 **Arguments**:
 
-- `origin` _str_ - Full path to file of origin
-- `line` _int_ - Overall line counter
-- `infileline` _int_ - Line counter in the particular file
 - `filename` _str_ - filename of the file that can't be found
 - `statement` _str_ - either include or require
-  
-
-**Arguments**:
-
-- `new_style_override_syntax` _bool_ - Use ':' a override delimiter (default: {False})
 
 <a id="oelint_parser.cls_item.MissingFile.Filename"></a>
 
@@ -2585,32 +2423,15 @@ Items representing addpylib statements in bitbake.
 #### \_\_init\_\_
 
 ```python
-def __init__(origin: str,
-             line: int,
-             infileline: int,
-             rawtext: str,
-             path: str,
-             namespace: str,
-             realraw: str,
-             new_style_override_syntax: bool = False) -> None
+def __init__(path: str, namespace: str, *args, **kwargs) -> None
 ```
 
 constructor
 
 **Arguments**:
 
-- `origin` _str_ - Full path to file of origin
-- `line` _int_ - Overall line counter
-- `infileline` _int_ - Line counter in the particular file
-- `rawtext` _str_ - Raw input string (except inline code blocks)
-- `realraw` _str_ - Unprocessed input
 - `path` _str_ - path to the namespace
 - `namespace` _str_ - namespace name
-  
-
-**Arguments**:
-
-- `new_style_override_syntax` _bool_ - Use ':' a override delimiter (default: {False})
 
 <a id="oelint_parser.cls_item.AddPylib.Path"></a>
 
@@ -2671,34 +2492,16 @@ Items representing addfragment statements in bitbake.
 #### \_\_init\_\_
 
 ```python
-def __init__(origin: str,
-             line: int,
-             infileline: int,
-             rawtext: str,
-             path: str,
-             variable: str,
-             flagged: str,
-             realraw: str,
-             new_style_override_syntax: bool = False) -> None
+def __init__(path: str, variable: str, flagged: str, *args, **kwargs) -> None
 ```
 
 constructor
 
 **Arguments**:
 
-- `origin` _str_ - Full path to file of origin
-- `line` _int_ - Overall line counter
-- `infileline` _int_ - Line counter in the particular file
-- `rawtext` _str_ - Raw input string (except inline code blocks)
-- `realraw` _str_ - Unprocessed input
 - `path` _str_ - path to the namespace
 - `variable` _str_ - variable name
 - `flagged` _str_ - flagged variable name(s)
-  
-
-**Arguments**:
-
-- `new_style_override_syntax` _bool_ - Use ':' a override delimiter (default: {False})
 
 <a id="oelint_parser.cls_item.AddFragements.Path"></a>
 
@@ -2774,30 +2577,14 @@ Items representing include_all statements in bitbake.
 #### \_\_init\_\_
 
 ```python
-def __init__(origin: str,
-             line: int,
-             infileline: int,
-             rawtext: str,
-             file: str,
-             realraw: str,
-             new_style_override_syntax: bool = False) -> None
+def __init__(file: str, *args, **kwargs) -> None
 ```
 
 constructor
 
 **Arguments**:
 
-- `origin` _str_ - Full path to file of origin
-- `line` _int_ - Overall line counter
-- `infileline` _int_ - Line counter in the particular file
-- `rawtext` _str_ - Raw input string (except inline code blocks)
-- `realraw` _str_ - Unprocessed input
 - `file` _str_ - path to the file
-  
-
-**Arguments**:
-
-- `new_style_override_syntax` _bool_ - Use ':' a override delimiter (default: {False})
 
 <a id="oelint_parser.cls_item.IncludeAll.File"></a>
 
@@ -2843,33 +2630,23 @@ Items that representing inherit(_defer) statements.
 #### \_\_init\_\_
 
 ```python
-def __init__(origin: str,
-             line: int,
-             infileline: int,
-             rawtext: str,
-             statement: str,
+def __init__(statement: str,
              classes: str,
-             realraw: str,
-             new_style_override_syntax: bool = False,
-             inherit_file_paths: Set[str] = None) -> None
+             inherit_file_paths: Set[str] = None,
+             *args,
+             **kwargs) -> None
 ```
 
 constructor
 
 **Arguments**:
 
-- `origin` _str_ - Full path to file of origin
-- `line` _int_ - Overall line counter
-- `infileline` _int_ - Line counter in the particular file
-- `rawtext` _str_ - Raw input string (except inline code blocks)
-- `realraw` _str_ - Unprocessed input
 - `class` _str_ - class code to inherit
 - `statement` _str_ - inherit statement (INHERIT, inherit or inherit_defer)
   
 
 **Arguments**:
 
-- `new_style_override_syntax` _bool_ - Use ':' a override delimiter (default: {False})
 - `inherit_file_paths` _Set[str]_ - Paths of the identified inherited classes
 
 <a id="oelint_parser.cls_item.Inherit.Class"></a>
@@ -2950,32 +2727,19 @@ Items representing unset statements in bitbake.
 #### \_\_init\_\_
 
 ```python
-def __init__(origin: str,
-             line: int,
-             infileline: int,
-             rawtext: str,
-             name: str,
-             realraw: str,
-             flag: str = "",
-             new_style_override_syntax: bool = False) -> None
+def __init__(name: str, flag: str = "", *args, **kwargs) -> None
 ```
 
 constructor
 
 **Arguments**:
 
-- `origin` _str_ - Full path to file of origin
-- `line` _int_ - Overall line counter
-- `infileline` _int_ - Line counter in the particular file
-- `rawtext` _str_ - Raw input string (except inline code blocks)
-- `realraw` _str_ - Unprocessed input
 - `name` _str_ - name of variable to be unset
   
 
 **Arguments**:
 
 - `flag` _str_ - Flag to unset
-- `new_style_override_syntax` _bool_ - Use ':' a override delimiter (default: {False})
 
 <a id="oelint_parser.cls_item.Unset.VarName"></a>
 

--- a/oelint_parser/cls_item.py
+++ b/oelint_parser/cls_item.py
@@ -27,6 +27,7 @@ class Item():
                  infileline: int,
                  rawtext: str,
                  realraw: str,
+                 inline_blocks: List[Tuple[str, str]],
                  new_style_override_syntax: bool = False) -> None:
         """constructor
 
@@ -44,6 +45,7 @@ class Item():
         self.__Origin = origin
         self.__InFileLine = infileline
         self.__IncludedFrom = []
+        self.__InlineBlocks = inline_blocks
         self.__RealRaw = realraw or rawtext
         self.__OverrideDelimiter = ':' if new_style_override_syntax else '_'
 
@@ -131,6 +133,10 @@ class Item():
         """
         return self.__OverrideDelimiter == ':'
 
+    @property
+    def InlineBlocks(self) -> List[Tuple[str, str]]:
+        return self.__InlineBlocks
+
     @staticmethod
     def safe_linesplit(string: str) -> List[str]:
         """Safely split an input line to chunks
@@ -141,7 +147,7 @@ class Item():
         Returns:
             list: list of chunks of original string
         """
-        return Item(None, None, None, None, None)._safe_linesplit(string)
+        return Item(None, None, None, None, None, [])._safe_linesplit(string)
 
     def _safe_linesplit(self, string: str) -> List[str]:
         return [x for x in RegexRpl.split(__safeline_split_regex__, string) if x]
@@ -255,31 +261,19 @@ class Variable(Item):
                           " ?= ", " ??= ", " := ", " .= ", " =+ ", " =. "]
 
     def __init__(self,
-                 origin: str,
-                 line: int,
-                 infileline: int,
-                 rawtext: str,
                  name: str,
                  value: str,
                  operator: str,
-                 realraw: str,
-                 new_style_override_syntax: bool = False) -> None:
+                 *args,
+                 **kwargs) -> None:
         """constructor
 
         Arguments:
-            origin {str} -- Full path to file of origin
-            line {int} -- Overall line counter
-            infileline {int} -- Line counter in the particular file
-            rawtext {str} -- Raw input string (except inline code blocks)
-            realraw {str} -- Unprocessed input
             name {str} -- Variable name
             value {str} -- Variable value
             operator {str} -- Operation performed to the variable
-
-        Keyword Arguments:
-            new_style_override_syntax {bool} -- Use ':' a override delimiter (default: {False})
         """
-        super().__init__(origin, line, infileline, rawtext, realraw, new_style_override_syntax)
+        super().__init__(*args, **kwargs)
         self.__VarName, self.__SubItem = self.extract_sub(name)
         self.__SubItems = [x for x in self.SubItem.split(
             self.OverrideDelimiter) if x]
@@ -465,25 +459,11 @@ class Comment(Item):
     CLASSIFIER = "Comment"
 
     def __init__(self,
-                 origin: str,
-                 line: int,
-                 infileline: int,
-                 rawtext: str,
-                 realraw: str,
-                 new_style_override_syntax: bool = False) -> None:
+                 *args,
+                 **kwargs) -> None:
         """constructor
-
-        Arguments:
-            origin {str} -- Full path to file of origin
-            line {int} -- Overall line counter
-            infileline {int} -- Line counter in the particular file
-            rawtext {str} -- Raw input string (except inline code blocks)
-            realraw {str} -- Unprocessed input
-
-        Keyword Arguments:
-            new_style_override_syntax {bool} -- Use ':' a override delimiter (default: {False})
         """
-        super().__init__(origin, line, infileline, rawtext, realraw, new_style_override_syntax)
+        super().__init__(*args, **kwargs)
 
     def get_items(self) -> List[str]:
         """Get single lines of block
@@ -503,31 +483,18 @@ class Include(Item):
     ATTR_FILEINCLUDED = "FileIncluded"
 
     def __init__(self,
-                 origin: str,
-                 line: int,
-                 infileline: int,
-                 rawtext: str,
                  incname: str,
                  fileincluded: str,
                  statement: str,
-                 realraw: str,
-                 new_style_override_syntax: bool = False) -> None:
+                 *args, **kwargs) -> None:
         """constructor
 
         Arguments:
-            origin {str} -- Full path to file of origin
-            line {int} -- Overall line counter
-            infileline {int} -- Line counter in the particular file
-            rawtext {str} -- Raw input string (except inline code blocks)
-            realraw {str} -- Unprocessed input
             incname {str} -- raw name of the include file
             fileincluded {str} -- path of the file included
             statement {str} -- either include or require
-
-        Keyword Arguments:
-            new_style_override_syntax {bool} -- Use ':' a override delimiter (default: {False})
         """
-        super().__init__(origin, line, infileline, rawtext, realraw, new_style_override_syntax)
+        super().__init__(*args, **kwargs)
         self.__IncName = incname
         self.__Statement = statement
         self.__FileIncluded = fileincluded
@@ -576,29 +543,20 @@ class Export(Item):
     ATTR_STATEMENT = "Value"
 
     def __init__(self,
-                 origin: str,
-                 line: int,
-                 infileline: int,
-                 rawtext: str,
                  name: str,
                  value: str,
-                 realraw: str,
-                 new_style_override_syntax: bool = False) -> None:
+                 *args,
+                 **kwargs) -> None:
         """constructor
 
         Arguments:
-            origin {str} -- Full path to file of origin
-            line {int} -- Overall line counter
-            infileline {int} -- Line counter in the particular file
-            rawtext {str} -- Raw input string (except inline code blocks)
-            realraw {str} -- Unprocessed input
             name {str} -- variable name of the export
             value {str} -- (optional) value of the export
 
         Keyword Arguments:
             new_style_override_syntax {bool} -- Use ':' a override delimiter (default: {False})
         """
-        super().__init__(origin, line, infileline, rawtext, realraw, new_style_override_syntax)
+        super().__init__(*args, **kwargs)
         self.__Name = name
         self.__Value = value
 
@@ -637,33 +595,22 @@ class Function(Item):
     CLASSIFIER = "Function"
 
     def __init__(self,
-                 origin: str,
-                 line: int,
-                 infileline: int,
-                 rawtext: str,
                  name: str,
                  body: str,
-                 realraw: str,
                  python: bool = False,
                  fakeroot: bool = False,
-                 new_style_override_syntax: bool = False) -> None:
+                 *args, **kwargs) -> None:
         """[summary]
 
         Arguments:
-            origin {str} -- Full path to file of origin
-            line {int} -- Overall line counter
-            infileline {int} -- Line counter in the particular file
-            rawtext {str} -- Raw input string (except inline code blocks)
-            realraw {str} -- Unprocessed input
             name {str} -- Raw function name
             body {str} -- Function body
 
         Keyword Arguments:
             python {bool} -- python function according to parser (default: {False})
             fakeroot {bool} -- uses fakeroot (default: {False})
-            new_style_override_syntax {bool} -- Use ':' a override delimiter (default: {False})
         """
-        super().__init__(origin, line, infileline, rawtext, realraw, new_style_override_syntax)
+        super().__init__(*args, **kwargs)
         self.__IsPython = python is not None
         self.__IsFakeroot = fakeroot is not None
         name = name or ""
@@ -672,7 +619,7 @@ class Function(Item):
             self.OverrideDelimiter) if x]
         self.__FuncBody = body
         self.__FuncBodyRaw = textwrap.dedent(
-            rawtext[rawtext.find("{") + 1:].rstrip().rstrip("}"))
+            self.Raw[self.Raw.find("{") + 1:].rstrip().rstrip("}"))
 
     @property
     def IsPython(self) -> bool:
@@ -804,27 +751,14 @@ class PythonBlock(Item):
     CLASSIFIER = "PythonBlock"
 
     def __init__(self,
-                 origin: str,
-                 line: int,
-                 infileline: int,
-                 rawtext: str,
                  name: str,
-                 realraw: str,
-                 new_style_override_syntax: bool = False) -> None:
+                 *args, **kwargs) -> None:
         """constructor
 
         Arguments:
-            origin {str} -- Full path to file of origin
-            line {int} -- Overall line counter
-            infileline {int} -- Line counter in the particular file
-            rawtext {str} -- Raw input string (except inline code blocks)
-            realraw {str} -- Unprocessed input
             name {str} -- Function name
-
-        Keyword Arguments:
-            new_style_override_syntax {bool} -- Use ':' a override delimiter (default: {False})
         """
-        super().__init__(origin, line, infileline, rawtext, realraw, new_style_override_syntax)
+        super().__init__(*args, **kwargs)
         self.__FuncName = name
 
     @property
@@ -856,33 +790,20 @@ class FlagAssignment(Item):
     CLASSIFIER = "FlagAssignment"
 
     def __init__(self,
-                 origin: str,
-                 line: int,
-                 infileline: int,
-                 rawtext: str,
                  name: str,
                  ident: str,
                  value: str,
                  varop: str,
-                 realraw: str,
-                 new_style_override_syntax: bool = False) -> None:
+                 *args, **kwargs) -> None:
         """constructor
 
         Arguments:
-            origin {str} -- Full path to file of origin
-            line {int} -- Overall line counter
-            infileline {int} -- Line counter in the particular file
-            rawtext {str} -- Raw input string (except inline code blocks)
-            realraw {str} -- Unprocessed input
             name {str} -- name of task to be modified
             ident {str} -- task flag
             value {str} -- value of modification
             varop {str} -- variable operation
-
-        Keyword Arguments:
-            new_style_override_syntax {bool} -- Use ':' a override delimiter (default: {False})
         """
-        super().__init__(origin, line, infileline, rawtext, realraw, new_style_override_syntax)
+        super().__init__(*args, **kwargs)
         self.__name = name
         self.__flag = ident
         self.__value = value
@@ -949,27 +870,14 @@ class FunctionExports(Item):
     CLASSIFIER = "FunctionExports"
 
     def __init__(self,
-                 origin: str,
-                 line: int,
-                 infileline: int,
-                 rawtext: str,
                  name: str,
-                 realraw: str,
-                 new_style_override_syntax: bool = False) -> None:
+                 *args, **kwargs) -> None:
         """constructor
 
         Arguments:
-            origin {str} -- Full path to file of origin
-            line {int} -- Overall line counter
-            infileline {int} -- Line counter in the particular file
-            rawtext {str} -- Raw input string (except inline code blocks)
-            realraw {str} -- Unprocessed input
             name {str} -- name of function to be exported
-
-        Keyword Arguments:
-            new_style_override_syntax {bool} -- Use ':' a override delimiter (default: {False})
         """
-        super().__init__(origin, line, infileline, rawtext, realraw, new_style_override_syntax)
+        super().__init__(*args, **kwargs)
         self.__FuncNames = name
 
     @property
@@ -1009,33 +917,22 @@ class TaskAdd(Item):
     CLASSIFIER = "TaskAdd"
 
     def __init__(self,
-                 origin: str,
-                 line: int,
-                 infileline: int,
-                 rawtext: str,
                  name: str,
-                 realraw: str,
                  before: str = "",
                  after: str = "",
                  comment: str = "",
-                 new_style_override_syntax: bool = False) -> None:
+                 *args, **kwargs) -> None:
         """constructor
 
         Arguments:
-            origin {str} -- Full path to file of origin
-            line {int} -- Overall line counter
-            infileline {int} -- Line counter in the particular file
-            rawtext {str} -- Raw input string (except inline code blocks)
-            realraw {str} -- Unprocessed input
             name {str} -- name of task to be executed
 
         Keyword Arguments:
             before {str} -- before statement (default: {""})
             after {str} -- after statement (default: {""})
             comment {str} -- optional comment (default: {""})
-            new_style_override_syntax {bool} -- Use ':' a override delimiter (default: {False})
         """
-        super().__init__(origin, line, infileline, rawtext, realraw, new_style_override_syntax)
+        super().__init__(*args, **kwargs)
         self.__FuncName = name
         self.__Before = [x for x in (before or "").split(" ") if x]
         self.__After = [x for x in (after or "").split(" ") if x]
@@ -1094,29 +991,16 @@ class TaskDel(Item):
     CLASSIFIER = "TaskDel"
 
     def __init__(self,
-                 origin: str,
-                 line: int,
-                 infileline: int,
-                 rawtext: str,
                  name: str,
                  comment: str,
-                 realraw: str,
-                 new_style_override_syntax: bool = False) -> None:
+                 *args, **kwargs) -> None:
         """constructor
 
         Arguments:
-            origin {str} -- Full path to file of origin
-            line {int} -- Overall line counter
-            infileline {int} -- Line counter in the particular file
-            rawtext {str} -- Raw input string (except inline code blocks)
-            realraw {str} -- Unprocessed input
             name {str} -- name of task to be executed
             comment {str} -- optional comment
-
-        Keyword Arguments:
-            new_style_override_syntax {bool} -- Use ':' a override delimiter (default: {False})
         """
-        super().__init__(origin, line, infileline, rawtext, realraw, new_style_override_syntax)
+        super().__init__(*args, **kwargs)
         self.__FuncName = name
         self.__Comment = comment or ''
 
@@ -1155,25 +1039,16 @@ class MissingFile(Item):
     CLASSIFIER = "MissingFile"
 
     def __init__(self,
-                 origin: str,
-                 line: int,
-                 infileline: int,
                  filename: str,
                  statement: str,
-                 new_style_override_syntax: bool = False) -> None:
+                 *args, **kwargs) -> None:
         """constructor
 
         Arguments:
-            origin {str} -- Full path to file of origin
-            line {int} -- Overall line counter
-            infileline {int} -- Line counter in the particular file
             filename {str} -- filename of the file that can't be found
             statement {str} -- either include or require
-
-        Keyword Arguments:
-            new_style_override_syntax {bool} -- Use ':' a override delimiter (default: {False})
         """
-        super().__init__(origin, line, infileline, "", "", new_style_override_syntax)
+        super().__init__(*args, **kwargs, rawtext='', realraw='')
         self.__Filename = filename
         self.__Statement = statement
 
@@ -1207,29 +1082,16 @@ class AddPylib(Item):
     ATTR_NAMESPACE = "Namespace"
 
     def __init__(self,
-                 origin: str,
-                 line: int,
-                 infileline: int,
-                 rawtext: str,
                  path: str,
                  namespace: str,
-                 realraw: str,
-                 new_style_override_syntax: bool = False) -> None:
+                 *args, **kwargs) -> None:
         """constructor
 
         Arguments:
-            origin {str} -- Full path to file of origin
-            line {int} -- Overall line counter
-            infileline {int} -- Line counter in the particular file
-            rawtext {str} -- Raw input string (except inline code blocks)
-            realraw {str} -- Unprocessed input
             path {str} -- path to the namespace
             namespace {str} -- namespace name
-
-        Keyword Arguments:
-            new_style_override_syntax {bool} -- Use ':' a override delimiter (default: {False})
         """
-        super().__init__(origin, line, infileline, rawtext, realraw, new_style_override_syntax)
+        super().__init__(*args, **kwargs)
         self.__Path = path
         self.__Namespace = namespace
 
@@ -1269,31 +1131,18 @@ class AddFragements(Item):
     ATTR_FLAGGED = "Flagged"
 
     def __init__(self,
-                 origin: str,
-                 line: int,
-                 infileline: int,
-                 rawtext: str,
                  path: str,
                  variable: str,  # noqa: VNE002
                  flagged: str,
-                 realraw: str,
-                 new_style_override_syntax: bool = False) -> None:
+                 *args, **kwargs) -> None:
         """constructor
 
         Arguments:
-            origin {str} -- Full path to file of origin
-            line {int} -- Overall line counter
-            infileline {int} -- Line counter in the particular file
-            rawtext {str} -- Raw input string (except inline code blocks)
-            realraw {str} -- Unprocessed input
             path {str} -- path to the namespace
             variable {str} -- variable name
             flagged {str} -- flagged variable name(s)
-
-        Keyword Arguments:
-            new_style_override_syntax {bool} -- Use ':' a override delimiter (default: {False})
         """
-        super().__init__(origin, line, infileline, rawtext, realraw, new_style_override_syntax)
+        super().__init__(*args, **kwargs)
         self.__Path = path
         self.__Variable = variable
         self.__Flagged = flagged
@@ -1341,27 +1190,14 @@ class IncludeAll(Item):
     ATTR_FILE = "File"
 
     def __init__(self,
-                 origin: str,
-                 line: int,
-                 infileline: int,
-                 rawtext: str,
                  file: str,  # noqa: VNE002
-                 realraw: str,
-                 new_style_override_syntax: bool = False) -> None:
+                 *args, **kwargs) -> None:
         """constructor
 
         Arguments:
-            origin {str} -- Full path to file of origin
-            line {int} -- Overall line counter
-            infileline {int} -- Line counter in the particular file
-            rawtext {str} -- Raw input string (except inline code blocks)
-            realraw {str} -- Unprocessed input
             file {str} -- path to the file
-
-        Keyword Arguments:
-            new_style_override_syntax {bool} -- Use ':' a override delimiter (default: {False})
         """
-        super().__init__(origin, line, infileline, rawtext, realraw, new_style_override_syntax)
+        super().__init__(*args, **kwargs)
         self.__File = file
 
     @property
@@ -1390,32 +1226,21 @@ class Inherit(Item):
     ATTR_CLASS = "Class"
 
     def __init__(self,
-                 origin: str,
-                 line: int,
-                 infileline: int,
-                 rawtext: str,
                  statement: str,
                  classes: str,
-                 realraw: str,
-                 new_style_override_syntax: bool = False,
                  inherit_file_paths: Set[str] = None,
+                 *args, **kwargs,
                  ) -> None:
         """constructor
 
         Arguments:
-            origin {str} -- Full path to file of origin
-            line {int} -- Overall line counter
-            infileline {int} -- Line counter in the particular file
-            rawtext {str} -- Raw input string (except inline code blocks)
-            realraw {str} -- Unprocessed input
             class {str} -- class code to inherit
             statement {str} -- inherit statement (INHERIT, inherit or inherit_defer)
 
         Keyword Arguments:
-            new_style_override_syntax {bool} -- Use ':' a override delimiter (default: {False})
             inherit_file_paths {Set[str]} -- Paths of the identified inherited classes
         """
-        super().__init__(origin, line, infileline, rawtext, realraw, new_style_override_syntax)
+        super().__init__(*args, **kwargs)
         self.__Class = classes
         self.__Statement = statement
         self.__FilePaths = inherit_file_paths or {}
@@ -1468,29 +1293,18 @@ class Unset(Item):
     CLASSIFIER = "Unset"
 
     def __init__(self,
-                 origin: str,
-                 line: int,
-                 infileline: int,
-                 rawtext: str,
                  name: str,
-                 realraw: str,
                  flag: str = "",
-                 new_style_override_syntax: bool = False) -> None:
+                 *args, **kwargs) -> None:
         """constructor
 
         Arguments:
-            origin {str} -- Full path to file of origin
-            line {int} -- Overall line counter
-            infileline {int} -- Line counter in the particular file
-            rawtext {str} -- Raw input string (except inline code blocks)
-            realraw {str} -- Unprocessed input
             name {str} -- name of variable to be unset
 
         Keyword Arguments:
             flag {str} -- Flag to unset
-            new_style_override_syntax {bool} -- Use ':' a override delimiter (default: {False})
         """
-        super().__init__(origin, line, infileline, rawtext, realraw, new_style_override_syntax)
+        super().__init__(*args, **kwargs)
         self.__VarName = name
         self.__Flag = flag
 

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -1,0 +1,228 @@
+import os
+import tempfile
+import textwrap
+import unittest
+
+
+class OelintLinking(unittest.TestCase):
+
+    def _create_tempfile(self, _input):
+        self.__created_files = getattr(self, '__created_files', {})
+        self._collected_tmpdirs = getattr(self, '_collect_tmpdirs', [])
+        self._tmpdir = getattr(self, '_tmpdir', tempfile.mkdtemp())
+        self._collected_tmpdirs.append(self._tmpdir)
+        _file = 'testfile.bb'
+        _path = os.path.join(self._tmpdir, _file)
+        os.makedirs(os.path.dirname(_path), exist_ok=True)
+
+        with open(_path, 'w') as o:
+            _cnt = textwrap.dedent(_input).lstrip('\n')
+            self.__created_files[_file] = _cnt
+            o.write(_cnt)
+            setattr(self, '__created_files', self.__created_files)
+        return _path
+
+    def test_expand_ref_other(self):
+        from oelint_parser.cls_stash import Stash
+        from oelint_parser.cls_item import Variable
+        self.__stash = Stash()
+        _file = self._create_tempfile(
+            '''
+            B = "${@some.function(d, foo)}"
+            A = "${B}/abc"
+            ''')
+        self.__stash.AddFile(_file)
+        self.__stash.Finalize()
+
+        _stash: list[Variable] = self.__stash.GetItemsFor(classifier=Variable.CLASSIFIER,
+                                                          attribute=Variable.ATTR_VAR,
+                                                          attributeValue="A")
+        self.assertTrue(_stash, msg="Stash has no items")
+        for item in _stash[0].get_items():
+            self.assertEqual(self.__stash.ExpandTerm(_file, item), '${@some.function(d, foo)}/abc')
+
+    def test_expand_inline_block(self):
+        from oelint_parser.cls_stash import Stash
+        from oelint_parser.cls_item import Variable
+        self.__stash = Stash()
+        _file = self._create_tempfile(
+            '''
+            A = "${@some.function(d, foo)}/abc"
+            ''')
+        self.__stash.AddFile(_file)
+        self.__stash.Finalize()
+
+        _stash: list[Variable] = self.__stash.GetItemsFor(classifier=Variable.CLASSIFIER,
+                                                          attribute=Variable.ATTR_VAR,
+                                                          attributeValue="A")
+        self.assertTrue(_stash, msg="Stash has no items")
+        for item in _stash[0].get_items():
+            self.assertEqual(self.__stash.ExpandTerm(_file, item, objref=_stash[0]), '${@some.function(d, foo)}/abc')
+
+    def test_expand_multiple_inline_block(self):
+        from oelint_parser.cls_stash import Stash
+        from oelint_parser.cls_item import Variable
+        self.__stash = Stash()
+        _file = self._create_tempfile(
+            '''
+            A = "${@some.function(d, foo)}/abc ${@some.function2(d, foo)}/def"
+            ''')
+        self.__stash.AddFile(_file)
+        self.__stash.Finalize()
+
+        _stash: list[Variable] = self.__stash.GetItemsFor(classifier=Variable.CLASSIFIER,
+                                                          attribute=Variable.ATTR_VAR,
+                                                          attributeValue="A")
+        self.assertTrue(_stash, msg="Stash has no items")
+        for item in _stash[0].get_items():
+            self.assertEqual(self.__stash.ExpandTerm(
+                _file, item, objref=_stash[0]), '${@some.function(d, foo)}/abc ${@some.function2(d, foo)}/def')
+
+    def test_expand_nested_ref(self):
+        from oelint_parser.cls_stash import Stash
+        from oelint_parser.cls_item import Variable
+        self.__stash = Stash()
+        _file = self._create_tempfile(
+            '''
+            B = "200"
+            C = "${@some.function(d, foo)}/${B}"
+            A = "${C}/abc"
+            ''')
+        self.__stash.AddFile(_file)
+        self.__stash.Finalize()
+
+        _stash: list[Variable] = self.__stash.GetItemsFor(classifier=Variable.CLASSIFIER,
+                                                          attribute=Variable.ATTR_VAR,
+                                                          attributeValue="A")
+        self.assertTrue(_stash, msg="Stash has no items")
+        for item in _stash[0].get_items():
+            self.assertEqual(self.__stash.ExpandTerm(_file, item, objref=_stash[0]), '${@some.function(d, foo)}/200/abc')
+
+    def test_expand_nested_python_ref(self):
+        from oelint_parser.cls_stash import Stash
+        from oelint_parser.cls_item import Variable
+        self.__stash = Stash()
+        _file = self._create_tempfile(
+            '''
+            B = "200"
+            C = "${@some.function(d, d.getVar('B'))}"
+            A = "${C}/abc"
+            ''')
+        self.__stash.AddFile(_file)
+        self.__stash.Finalize()
+
+        _stash: list[Variable] = self.__stash.GetItemsFor(classifier=Variable.CLASSIFIER,
+                                                          attribute=Variable.ATTR_VAR,
+                                                          attributeValue="A")
+        self.assertTrue(_stash, msg="Stash has no items")
+        for item in _stash[0].get_items():
+            self.assertEqual(self.__stash.ExpandTerm(_file, item, objref=_stash[0]), '${@some.function(d, 200)}/abc')
+
+    def test_expand_file_ref(self):
+        from oelint_parser.cls_stash import Stash
+        from oelint_parser.cls_item import Variable
+        self.__stash = Stash()
+        _file = self._create_tempfile(
+            '''
+            C = "${@some.function(d, d.getVar('FILE'))}"
+            A = "${C}/abc"
+            ''')
+        self.__stash.AddFile(_file)
+        self.__stash.Finalize()
+
+        _stash: list[Variable] = self.__stash.GetItemsFor(classifier=Variable.CLASSIFIER,
+                                                          attribute=Variable.ATTR_VAR,
+                                                          attributeValue="A")
+        self.assertTrue(_stash, msg="Stash has no items")
+        for item in _stash[0].get_items():
+            self.assertEqual(self.__stash.ExpandTerm(_file, item, objref=_stash[0]), f'${{@some.function(d, "{_file}")}}/abc')
+
+    def test_expandvar_ref_other(self):
+        from oelint_parser.cls_stash import Stash
+        from oelint_parser.cls_item import Variable
+        self.__stash = Stash()
+        _file = self._create_tempfile(
+            '''
+            B = "${@some.function(d, foo)}"
+            A = "${B}/abc"
+            ''')
+        self.__stash.AddFile(_file)
+        self.__stash.Finalize()
+
+        res = self.__stash.ExpandVar(_file, attribute=Variable.ATTR_VAR, attributeValue='A')
+        self.assertEqual(' '.join(res.get('A', '')), '${@some.function(d, foo)}/abc')
+
+    def test_expandvar_inline_block(self):
+        from oelint_parser.cls_stash import Stash
+        from oelint_parser.cls_item import Variable
+        self.__stash = Stash()
+        _file = self._create_tempfile(
+            '''
+            A = "${@some.function(d, foo)}/abc"
+            ''')
+        self.__stash.AddFile(_file)
+        self.__stash.Finalize()
+
+        res = self.__stash.ExpandVar(_file, attribute=Variable.ATTR_VAR, attributeValue='A')
+        self.assertEqual(' '.join(res.get('A', '')), '${@some.function(d, foo)}/abc')
+
+    def test_expandvar_multiple_inline_block(self):
+        from oelint_parser.cls_stash import Stash
+        from oelint_parser.cls_item import Variable
+        self.__stash = Stash()
+        _file = self._create_tempfile(
+            '''
+            A = "${@some.function(d, foo)}/abc ${@some.function2(d, foo)}/def"
+            ''')
+        self.__stash.AddFile(_file)
+        self.__stash.Finalize()
+
+        res = self.__stash.ExpandVar(_file, attribute=Variable.ATTR_VAR, attributeValue='A')
+        self.assertEqual(' '.join(res.get('A', '')), '${@some.function(d, foo)}/abc ${@some.function2(d, foo)}/def')
+
+    def test_expandvar_nested_ref(self):
+        from oelint_parser.cls_stash import Stash
+        from oelint_parser.cls_item import Variable
+        self.__stash = Stash()
+        _file = self._create_tempfile(
+            '''
+            B = "200"
+            C = "${@some.function(d, foo)}/${B}"
+            A = "${C}/abc"
+            ''')
+        self.__stash.AddFile(_file)
+        self.__stash.Finalize()
+
+        res = self.__stash.ExpandVar(_file, attribute=Variable.ATTR_VAR, attributeValue='A')
+        self.assertEqual(' '.join(res.get('A', '')), '${@some.function(d, foo)}/200/abc')
+
+    def test_expandvar_nested_python_ref(self):
+        from oelint_parser.cls_stash import Stash
+        from oelint_parser.cls_item import Variable
+        self.__stash = Stash()
+        _file = self._create_tempfile(
+            '''
+            B = "200"
+            C = "${@some.function(d, d.getVar('B'))}"
+            A = "${C}/abc"
+            ''')
+        self.__stash.AddFile(_file)
+        self.__stash.Finalize()
+
+        res = self.__stash.ExpandVar(_file, attribute=Variable.ATTR_VAR, attributeValue='A')
+        self.assertEqual(' '.join(res.get('A', '')), '${@some.function(d, 200)}/abc')
+
+    def test_expandvar_file_ref(self):
+        from oelint_parser.cls_stash import Stash
+        from oelint_parser.cls_item import Variable
+        self.__stash = Stash()
+        _file = self._create_tempfile(
+            '''
+            C = "${@some.function(d, d.getVar('FILE'))}"
+            A = "${C}/abc"
+            ''')
+        self.__stash.AddFile(_file)
+        self.__stash.Finalize()
+
+        res = self.__stash.ExpandVar(_file, attribute=Variable.ATTR_VAR, attributeValue='A')
+        self.assertEqual(' '.join(res.get('A', '')), f'${{@some.function(d, "{_file}")}}/abc')

--- a/tests/test_linking.py
+++ b/tests/test_linking.py
@@ -29,7 +29,3 @@ class OelintLinking(unittest.TestCase):
         _links = sorted({os.path.basename(y.Origin) for y in _stash})
         self.assertEqual(_links, ['global-foo.bbclass', 'recipe-foo.bbclass',
                          'test.inc', 'test2.inc', 'test3.inc', 'test_2.bb'])
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -493,7 +493,7 @@ class OelintParserTest(unittest.TestCase):
 
         assert len(_stash) == 2
 
-        new_comment = Comment('foo', 1, 1, '# abc', '# def')
+        new_comment = Comment('foo', 1, 1, '# abc', '# def', [])
         self.__stash.Append(new_comment)
 
         _stash = self.__stash.GetItemsFor(classifier=Comment.CLASSIFIER)


### PR DESCRIPTION
for the stash functions ExpandTerm and ExpandVar.
This will turn any found inline blocks back to their respective values, as found while parsing.

Also add support to expand d.getVar statements
and FILE references automatically.

Closes #285