### PR TITLE
stash: handle ValueError in GetScrComponents

### DIFF
--- a/oelint_parser/cls_stash.py
+++ b/oelint_parser/cls_stash.py
@@ -605,7 +605,10 @@ class Stash():
             dict -- scheme: protocol used, src: source URI, options: parsed options
         """
         _raw = self._replace_with_known_mirrors(string)
-        _url = urlparse(self._replace_with_known_mirrors(string))
+        try:
+            _url = urlparse(self._replace_with_known_mirrors(string))
+        except ValueError:
+            return {"scheme": '', "src": '', "options": {}}
         _scheme = _url.scheme
         _tmp = _url.netloc
         if _url.path:

--- a/tests/test_parser_syntax_issues.py
+++ b/tests/test_parser_syntax_issues.py
@@ -60,3 +60,31 @@ class OelintParserSyntaxIssuesTest(unittest.TestCase):
 
         for x in _stash:
             self.assertEqual(x.FuncName, 'do-bar')
+
+    def test_urlparse(self):
+        from oelint_parser.cls_item import TaskDel
+        from oelint_parser.cls_stash import Stash
+
+        self.__stash = Stash()
+
+        res = self.__stash.GetScrComponents('http://foo.bar/baz.git;test1=1;test2=2')
+
+        assert "scheme" in res
+        assert "src" in res
+        assert "options" in res
+
+        assert "http" == res["scheme"]
+        assert "foo.bar/baz.git" == res["src"]
+        assert "test1" in res["options"]
+        assert "test2" in res["options"]
+
+        res = self.__stash.GetScrComponents("file://${@'.'.join(d.getVar('LINUX_VERSION').split('.')[0:2])};test1=1;test2=2")
+
+        assert "scheme" in res
+        assert "src" in res
+        assert "options" in res
+
+        assert not res["scheme"]
+        assert not res["src"]
+        assert "test1" not in res["options"]
+        assert "test2" not in res["options"]


### PR DESCRIPTION
as potentially illegal urls can be passed,
so it's better to handle the exception and return some dummy value than to crash

Closes #293