### PR TITLE
stash/reduce: turn file into abspath

### DIFF
--- a/oelint_parser/cls_stash.py
+++ b/oelint_parser/cls_stash.py
@@ -306,6 +306,7 @@ class Stash():
 
     @functools.cache  # noqa: B019
     def __is_linked_to(self, item: Item, filename: str, nolink: bool = False) -> bool:
+        filename = os.path.abspath(filename)
         return (item.Origin in self.__map.get(filename, {}) and not nolink) or filename == item.Origin
 
     @functools.cache  # noqa: B019


### PR DESCRIPTION
the stash init automatically turns non abs paths into absolute paths, so we need to do the same when
items are requested, otherwise when a relative path is requested no items would match the filter