### PR TITLE
parser: allow file to be ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,17 +181,19 @@ Those can be easily modified, in case you have additional information to add/rem
 The actual database is not directly accessible by the user, but a few methods in the `oelint_parse.constants.CONSTANT` class do exist.
 Each of the method accepts a dictionary with the same key mapping as listed below (multilevel paths are displayed a JSON pointer)
 
-| key                        | type | description                                           | getter for information                                     |
-| -------------------------- | ---- | ----------------------------------------------------- | ---------------------------------------------------------- |
-| functions/known            | list | known functions                                       | `oelint_parse.constants.CONSTANT.FunctionsKnown`           |
-| functions/order            | list | preferred order of core functions                     | `oelint_parse.constants.CONSTANT.FunctionsOrder`           |
-| images/known-classes       | list | bbclasses to be known to be used in images            | `oelint_parse.constants.CONSTANT.ImagesClasses`            |
-| images/known-variables     | list | variables known to be used in images                  | `oelint_parse.constants.CONSTANT.ImagesVariables`          |
-| replacements/distros       | list | known distro overrides                                | `oelint_parse.constants.CONSTANT.DistrosKnown`             |
-| replacements/machines      | list | known machine overrides                               | `oelint_parse.constants.CONSTANT.MachinesKnown`            |
-| replacements/mirrors       | dict | known mirrors                                         | `oelint_parse.constants.CONSTANT.MirrorsKnown`             |
-| variables/known            | list | known variables                                       | `oelint_parse.constants.CONSTANT.VariablesKnown`           |
-| sets/base                  | dict | base set of variables always used for value expansion | `oelint_parse.constants.CONSTANT.SetsBase`                 |
+| key                    | type | description                                           | getter for information                            |
+| ---------------------- | ---- | ----------------------------------------------------- | ------------------------------------------------- |
+| functions/known        | list | known functions                                       | `oelint_parse.constants.CONSTANT.FunctionsKnown`  |
+| functions/order        | list | preferred order of core functions                     | `oelint_parse.constants.CONSTANT.FunctionsOrder`  |
+| ignore/classes         | list | classes to ignore in parsing                          | `oelint_parse.constants.CONSTANT.ClassIgnore`     |
+| ignore/include         | list | include/require files to ignore in parsing            | `oelint_parse.constants.CONSTANT.IncludeIgnore`   |
+| images/known-classes   | list | bbclasses to be known to be used in images            | `oelint_parse.constants.CONSTANT.ImagesClasses`   |
+| images/known-variables | list | variables known to be used in images                  | `oelint_parse.constants.CONSTANT.ImagesVariables` |
+| replacements/distros   | list | known distro overrides                                | `oelint_parse.constants.CONSTANT.DistrosKnown`    |
+| replacements/machines  | list | known machine overrides                               | `oelint_parse.constants.CONSTANT.MachinesKnown`   |
+| replacements/mirrors   | dict | known mirrors                                         | `oelint_parse.constants.CONSTANT.MirrorsKnown`    |
+| sets/base              | list | base set of variables always used for value expansion | `oelint_parse.constants.CONSTANT.SetsBase`        |
+| variables/known        | list | known variables                                       | `oelint_parse.constants.CONSTANT.VariablesKnown`  |
 
 For additional constants
 

--- a/oelint_parser/constants.py
+++ b/oelint_parser/constants.py
@@ -168,5 +168,23 @@ class Constants():
         """
         return self.GetByPath('sets/base')
 
+    @property
+    def ClassIgnore(self) -> List[str]:
+        """_summary_
+
+        Returns:
+            List[str]: List of classes to ignore
+        """
+        return self.GetByPath('ignore/classes')
+
+    @property
+    def IncludeIgnore(self) -> List[str]:
+        """Includes to ignore
+
+        Returns:
+            List[str]: List of paths to ignore
+        """
+        return self.GetByPath('ignore/include')
+
 
 CONSTANTS = getattr(sys.modules[__name__], 'CONSTANTS', Constants())

--- a/oelint_parser/data/const-default.json
+++ b/oelint_parser/data/const-default.json
@@ -13,6 +13,10 @@
             "do_package"
         ]
     },
+    "ignore": {
+        "classes": [],
+        "include": []
+    },
     "images": {
         "known-classes": [
             "baremetal-image",

--- a/oelint_parser/parser.py
+++ b/oelint_parser/parser.py
@@ -24,6 +24,7 @@ from oelint_parser.cls_item import (
 )
 from oelint_parser.inlinerep import inlinerep
 from oelint_parser.rpl_regex import RegexRpl
+from oelint_parser.constants import CONSTANTS
 
 INLINE_BLOCK = "!!!inlineblock!!!"
 
@@ -31,25 +32,35 @@ __regex_var = regex.compile(
     r"^(?P<varname>([A-Z0-9a-z_.-]|\$|\{|\}|:)+?)(?P<varop>(\s|\t)*(\+|\?|\:|\.)*=(\+|\.)*(\s|\t)*)(?P<varval>.*)")
 __regex_func = regex.compile(
     r"^((?P<py>python)\s*|(?P<fr>fakeroot\s*))*(?P<func>[\w\.\-\+\{\}:\$]+)?\s*\(\s*\)\s*\{(?P<funcbody>.*)\s*\}")
-__regex_inherit = regex.compile(r"^(\s|\t)*(?P<statement>inherit(_defer)*)(\s+|\t+)(?P<inhname>.+)")
-__regex_inherit_glob = regex.compile(r"^INHERIT(?P<varop>(\s|\t)*(\+|\?|\:|\.)*=(\+|\.)*(\s|\t)*)('|\")(?P<inhname>.*)('|\")")
-__regex_export_wval = regex.compile(r"^\s*?export(\s+|\t+)(?P<name>.+)\s*=\s*\"(?P<value>.*)\"")
+__regex_inherit = regex.compile(
+    r"^(\s|\t)*(?P<statement>inherit(_defer)*)(\s+|\t+)(?P<inhname>.+)")
+__regex_inherit_glob = regex.compile(
+    r"^INHERIT(?P<varop>(\s|\t)*(\+|\?|\:|\.)*=(\+|\.)*(\s|\t)*)('|\")(?P<inhname>.*)('|\")")
+__regex_export_wval = regex.compile(
+    r"^\s*?export(\s+|\t+)(?P<name>.+)\s*=\s*\"(?P<value>.*)\"")
 __regex_export_woval = regex.compile(r"^\s*?export(\s+|\t+)(?P<name>.+)\s*$")
 __regex_comments = regex.compile(r"^(\s|\t)*#+\s*(?P<body>.*)")
 __regex_comments_pure = regex.compile(r"^#+\s*(?P<body>.*)")
-__regex_python = regex.compile(r"^(\s*|\t*)def(\s+|\t+)(?P<funcname>[a-z0-9_\-]+)(\s*|\t*)\(.*\)\:")
-__regex_include = regex.compile(r"^(\s*|\t*)(?P<statement>include|require)(\s+|\t+)(?P<incname>[A-za-z0-9\-\./\$\{\}]+)")
+__regex_python = regex.compile(
+    r"^(\s*|\t*)def(\s+|\t+)(?P<funcname>[a-z0-9_\-]+)(\s*|\t*)\(.*\)\:")
+__regex_include = regex.compile(
+    r"^(\s*|\t*)(?P<statement>include|require)(\s+|\t+)(?P<incname>[A-za-z0-9\-\./\$\{\}]+)")
 __regex_addtask = regex.compile(
     r"^(\s*|\t*)addtask\s+(?P<func>[\w\-]+)\s*((before\s*(?P<before>(([^#\n]*(?=after))|([^#\n]*))))|(after\s*(?P<after>(([^#\n]*(?=before))|([^#\n]*)))))*(?P<comment>#.*|.*?)")
-__regex_deltask = regex.compile(r"^(\s*|\t*)deltask\s+(?P<func>[\w\-]+)\s*(?P<comment>#.*)*")
+__regex_deltask = regex.compile(
+    r"^(\s*|\t*)deltask\s+(?P<func>[\w\-]+)\s*(?P<comment>#.*)*")
 __regex_flagass = regex.compile(
     r"^(\s*|\t*)(?P<name>([A-Z0-9a-z_.-]|\$|\{|\}|:)+?)\[(?P<ident>(\w|-|\.|/|@|_)+)\](?P<varop>(\s|\t)*(\+|\?|\:|\.)*=(\+|\.)*(\s|\t)*)(?P<varval>.*)")
 __regex_export_func = regex.compile(r"^EXPORT_FUNCTIONS\s+(?P<func>.*)")
-__regex_addpylib = regex.compile(r"^(\s+|\t*)addpylib(\s+|\t+)(?P<path>\$\{LAYERDIR\}/.+)(\s+|\t+)(?P<namespace>.*)")
-__regex_unset = regex.compile(r"^(\s+|\t+)*unset(\s+|\t+)+(?P<varname>.+?)(\[*(?P<flag>.+)\])*")
-__regex_addfragments = regex.compile(r"addfragments\s+(?P<path>.+)\s+(?P<variable>.+)\s+(?P<flagged>.+)")
+__regex_addpylib = regex.compile(
+    r"^(\s+|\t*)addpylib(\s+|\t+)(?P<path>\$\{LAYERDIR\}/.+)(\s+|\t+)(?P<namespace>.*)")
+__regex_unset = regex.compile(
+    r"^(\s+|\t+)*unset(\s+|\t+)+(?P<varname>.+?)(\[*(?P<flag>.+)\])*")
+__regex_addfragments = regex.compile(
+    r"addfragments\s+(?P<path>.+)\s+(?P<variable>.+)\s+(?P<flagged>.+)")
 __regex_includeall = regex.compile(r"include_all\s+(?P<file>.+)")
-__func_start_regexp__ = regex.compile(r".*(((?P<py>python)|(?P<fr>fakeroot))\s*)*(?P<func>[\w\.\-\+\{\}\$]+)?\s*\(\s*\)\s*\{")
+__func_start_regexp__ = regex.compile(
+    r".*(((?P<py>python)|(?P<fr>fakeroot))\s*)*(?P<func>[\w\.\-\+\{\}\$]+)?\s*\(\s*\)\s*\{")
 __next_line_regex__ = regex.compile(r"\\\s*\n")
 __valid_func_name_regex__ = regex.compile(r"^[A-Za-z0-9#]+")
 
@@ -200,11 +211,13 @@ def prepare_lines(_file: str, lineOffset: int = 0, negative: bool = False) -> Li
                 elif line is None:
                     line = ''
                 line = nextbuf + line
-                item, nextbuf, length = prepare_lines_subparser(_iter, lineOffset, num, line, negative=negative)
+                item, nextbuf, length = prepare_lines_subparser(
+                    _iter, lineOffset, num, line, negative=negative)
                 num += length
                 prep_lines.append(item)
                 if nextbuf:
-                    item, nextbuf, length = prepare_lines_subparser(_iter, lineOffset, num, nextbuf, negative=negative)
+                    item, nextbuf, length = prepare_lines_subparser(
+                        _iter, lineOffset, num, nextbuf, negative=negative)
                     num += length
                     prep_lines.append(item)
     except FileNotFoundError:
@@ -298,7 +311,8 @@ def get_items(stash: object,
                     break
                 elif k == "unset":
                     parameter['name'] = m.group("varname")
-                    parameter['flag'] = (m.groupdict().get("flag", "") or "").strip('[]')
+                    parameter['flag'] = (m.groupdict().get(
+                        "flag", "") or "").strip('[]')
                     res.append(Unset(**parameter))
                     good = True
                     break
@@ -320,6 +334,8 @@ def get_items(stash: object,
                             if _path:
                                 break
                         if _path:
+                            if inhname in CONSTANTS.ClassIgnore:
+                                continue
                             _found_paths.add(_path)
                             tmp = stash.AddFile(
                                 _path, lineOffset=line["line"], forcedLink=_file)
@@ -345,6 +361,8 @@ def get_items(stash: object,
                             if _path:
                                 break
                         if _path:
+                            if inhname in CONSTANTS.ClassIgnore:
+                                continue
                             _found_paths.add(_path)
                             tmp = stash.AddFile(
                                 _path, lineOffset=line["line"], forcedLink=_file)
@@ -404,9 +422,12 @@ def get_items(stash: object,
                     good = True
                     break
                 elif k == "include":
+                    includename = stash.ExpandTerm(_file, m.group("incname"))
                     _path = stash.FindLocalOrLayer(
-                        stash.ExpandTerm(_file, m.group("incname")), os.path.dirname(_file))
+                        includename, os.path.dirname(_file))
                     if _path:
+                        if includename in CONSTANTS.IncludeIgnore:
+                            continue
                         tmp = stash.AddFile(
                             _path, lineOffset=line["line"], forcedLink=_file)
                         if any(tmp):


### PR DESCRIPTION
with the new constants interface
- ignore/include
- ignore/classes

that will simply skip the additional
file lookup while parsing

Relates to https://github.com/priv-kweihmann/oelint-adv/discussions/827